### PR TITLE
Removed input for tagging intital checksum

### DIFF
--- a/.github/workflows/generate-initial-checksums.yml
+++ b/.github/workflows/generate-initial-checksums.yml
@@ -13,7 +13,7 @@ on:
       committed-checksum-location:
         type: string
         required: false
-        default: ./testing/checksums
+        default: ./testing/checksum
         description: "If `commit-checksums`: Where in the repository the generated checksums should be committed to."
 jobs:
   generate-checksums:

--- a/.github/workflows/generate-initial-checksums.yml
+++ b/.github/workflows/generate-initial-checksums.yml
@@ -15,10 +15,6 @@ on:
         required: false
         default: ./testing/checksums
         description: "If `commit-checksums`: Where in the repository the generated checksums should be committed to."
-      committed-checksum-tag:
-        type: string
-        required: false
-        description: "If `commit-checksums`: An optional tag to attach to the committed checksums"
 jobs:
   generate-checksums:
     name: Generate Checksums


### PR DESCRIPTION
In this PR:
* Removed the `committed-checksum-tag` input as it is not used. 
* Updated `committed-checksum-location` default