### PR TITLE
pr-1-ci.yml: Added prerequisite job to check PR branch names

### DIFF
--- a/.github/workflows/pr-1-ci.yml
+++ b/.github/workflows/pr-1-ci.yml
@@ -31,12 +31,62 @@ jobs:
         id: head-commit
         run: echo "authorship=$(git log -1 --pretty=format:'%an')" >> $GITHUB_OUTPUT
 
+  branch-check:
+    name: PR Source Branch Check
+    # This check is run to confirm that the source branch is of the form `dev-<config>`
+    # and the target branch is of the form `release-<config>`. We are being especially
+    # concerned with branch names because deployment to GitHub Environments can only
+    # be done on source branches with a certain pattern. See #20.
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: Check Source
+        run: |
+          if [[ "${{ startsWith(github.head_ref, 'dev-') }}" == "false" ]]; then
+            echo "::error::Source branch ${{ github.head_ref }} doesn't match 'dev-*'"
+            exit 1
+          fi
+
+      - name: Check Target
+        run: |
+          if [[ "${{ startsWith(github.base_ref, 'release-') }}" == "false" ]]; then
+            echo "::error::Target branch ${{ github.base_ref }} doesn't match 'release-*'"
+            exit 1
+          fi
+
+      - name: Compare Source and Target Config Names
+        # In this step, we cut the 'dev-' and 'release-' to compare config names directly.
+        run: |
+          source=$(cut --delimiter '-' --field 2 <<< "${{ github.head_ref }}")
+          target=$(cut --delimiter '-' --field 2 <<< "${{ github.base_ref }}")
+          if [[ "${source}" != "${target}" ]]; then
+            echo "::error::Config name of Source branch '${source}' does not match Target branch '${target}'"
+            exit 1
+          fi
+
+      - name: Failure Notifier
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          BODY: |
+            :x: Automated testing cannot be run on this branch :x:
+            Source and Target branches must be of the form `dev-<config>` and `release-<config>` respectively, and `<config>` must match between them.
+            Rename the Source branch or check the Target branch, and try again.
+        run: gh pr comment --body '${{ env.BODY }}'
+
   repro-ci:
     # run the given config on the deployment GitHub Environment (`environment-name`) and
     # upload the checksums and test details
     needs:
       - commit-check
-    if: needs.commit-check.outputs.authorship != 'github-actions'
+      - branch-check
+    if: needs.commit-check.outputs.authorship != 'github-actions' && needs.branch-check.result == 'success'
     uses: access-nri/reproducibility/.github/workflows/checks.yml@main
     with:
       model-name: access-om2

--- a/.github/workflows/pr-1-ci.yml
+++ b/.github/workflows/pr-1-ci.yml
@@ -62,8 +62,8 @@ jobs:
       - name: Compare Source and Target Config Names
         # In this step, we cut the 'dev-' and 'release-' to compare config names directly.
         run: |
-          source=$(cut --delimiter '-' --field 2 <<< "${{ github.head_ref }}")
-          target=$(cut --delimiter '-' --field 2 <<< "${{ github.base_ref }}")
+          source=$(cut --delimiter '-' --field 2- <<< "${{ github.head_ref }}")
+          target=$(cut --delimiter '-' --field 2- <<< "${{ github.base_ref }}")
           if [[ "${source}" != "${target}" ]]; then
             echo "::error::Config name of Source branch '${source}' does not match Target branch '${target}'"
             exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ access-om2.out
 .DS_Store
 ._*
 .vscode
+.pytest_cache

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 ### Changes to ACCESS-OM2 Configs
 
-1. Make your changes, test them, and open a PR to either the `release-*` or `dev-*` branch of a particular configuration.
+1. Make your changes, test them, and open a PR from the `dev-*` branch to the `release-*` branch of a particular configuration.
 2. Checks will run to note whether your changes break reproducibility with the current major version config tag on the target branch. For example, if you are opening a PR on the `release-1deg_jra55_iaf` branch, and the last tagged version on this branch is `release-1deg_jra55_iaf-1.2`, the checksums between the config in your PR and the checksum in the config tag are compared.
 3. A comment will be posted on the PR when this is completed, notifying you whether the checksums match (meaning a minor bump to `*-1.3`), or are different (meaning a major bump to `*-3.0`).
 4. Optionally, you can now modify your PR and get more reproducibility checks.
@@ -12,4 +12,15 @@
 
 ### Changes to the CI Infrastructure
 
-Changes to the CI Infrastructure are made to the `main` branch in this repository. Since the logic in the CI infrastructure is quite involved, it would be a good idea to read the [README-DEV.md](./README-DEV.md).
+Changes to the CI Infrastructure are made to the `main` branch in this repository, and then incorporated into each config branch, using the following:
+
+```bash
+git checkout main
+git subtree split -P .github -b ci
+git checkout  # some config branch
+git subtree add --squash -P .github ci  # can also subtree merge if the branch is still there locally
+# can also delete the local branch at the end with:
+git branch -D ci
+```
+
+Since the logic in the CI infrastructure is quite involved, it would be a good idea to read the [README-DEV.md](./README-DEV.md).


### PR DESCRIPTION
In this PR:
* Added a new job that will check that the source branch matches `dev-<config>` and the target branch matches `release-<config>`, with both `<config>`s matching. This is so we can have deploy to GitHub Environments that are protected by only allowing runs from protected branches. 
* Added more notes to the CONTRIBUTING.md

Closes #20 