### PR TITLE
CI Propagation

### DIFF
--- a/.github/workflows/call-pr-1-ci.yml
+++ b/.github/workflows/call-pr-1-ci.yml
@@ -18,7 +18,7 @@ jobs:
   call:
     # We simply call the workflow on main so we don't have to propagate CI changes to
     # multiple config branches all the time.
-    uses: codegat-test-org/configs/.github/workflows/pr-1-ci.yml@main
+    uses: access-nri/access-om2-configs/.github/workflows/pr-1-ci.yml@main
     secrets: inherit
     permissions:
       contents: write

--- a/.github/workflows/call-pr-1-ci.yml
+++ b/.github/workflows/call-pr-1-ci.yml
@@ -1,0 +1,26 @@
+# This workflow is used to convert the `.version` in the `metadata.yaml` file into a valid `git tag` on push to `main`.
+# We use the `.version` field in that file to denote the version of the config once a PR is merged.
+name: pr-1-ci.yml
+on:
+  pull_request:
+    branches:
+      - 'release-*'
+      - 'dev-*'
+    paths-ignore:
+      # These are ignored because they don't have anything to do with the model itself
+      - .github/**
+      - tools/**
+      - doc/**
+      - .*
+      - metadata.yaml
+      - README.md
+jobs:
+  call:
+    # We simply call the workflow on main so we don't have to propagate CI changes to
+    # multiple config branches all the time.
+    uses: codegat-test-org/configs/.github/workflows/pr-1-ci.yml@main
+    secrets: inherit
+    permissions:
+      contents: write
+      pull-requests: write
+      checks: write

--- a/.github/workflows/call-pr-3-bump-tag.yml
+++ b/.github/workflows/call-pr-3-bump-tag.yml
@@ -13,7 +13,7 @@ jobs:
   call:
     # We simply call the workflow on main so we don't have to propagate CI changes to
     # multiple config branches all the time.
-    uses: codegat-test-org/configs/.github/workflows/pr-3-bump-tag.yml@main
+    uses: access-nri/access-om2-configs/.github/workflows/pr-3-bump-tag.yml@main
     secrets: inherit
     permissions:
       contents: write

--- a/.github/workflows/call-pr-3-bump-tag.yml
+++ b/.github/workflows/call-pr-3-bump-tag.yml
@@ -1,0 +1,19 @@
+# This workflow is used to convert the `.version` in the `metadata.yaml` file
+# into a valid `git tag` on push to `main`.
+# We use the `.version` field in that file to denote the version of the config
+# once a PR is merged.
+name: Call pr-3-bump-tag.yml
+on:
+  push:
+    branches:
+      - 'release-*'
+    paths:
+      - 'metadata.yaml'
+jobs:
+  call:
+    # We simply call the workflow on main so we don't have to propagate CI changes to
+    # multiple config branches all the time.
+    uses: codegat-test-org/configs/.github/workflows/pr-3-bump-tag.yml@main
+    secrets: inherit
+    permissions:
+      contents: write

--- a/.github/workflows/pr-1-ci.yml
+++ b/.github/workflows/pr-1-ci.yml
@@ -1,17 +1,19 @@
 name: PR Checks
 on:
-  pull_request:
-    branches:
-      - 'release-*'
-      - 'dev-*'
-    paths-ignore:
-      # These are ignored because they don't have anything to do with the model itself
-      - .github/**
-      - tools/**
-      - doc/**
-      - .*
-      - metadata.yaml
-      - README.md
+  workflow_call:
+  # Workflows that call this workflow use the following triggers:
+  # pull_request:
+  #   branches:
+  #     - 'release-*'
+  #     - 'dev-*'
+  #   paths-ignore:
+  #     # These are ignored because they don't have anything to do with the model itself
+  #     - .github/**
+  #     - tools/**
+  #     - doc/**
+  #     - .*
+  #     - metadata.yaml
+  #     - README.md
 jobs:
   commit-check:
     name: Commit Check

--- a/.github/workflows/pr-3-bump-tag.yml
+++ b/.github/workflows/pr-3-bump-tag.yml
@@ -2,11 +2,13 @@
 # We use the `.version` field in that file to denote the version of the config once a PR is merged.
 name: Bump Tag
 on:
-  push:
-    branches:
-      - 'release-*'
-    paths:
-      - 'metadata.yaml'
+  workflow_call:
+  # Workflows that call this workflow use the following triggers:
+  # push:
+  #   branches:
+  #     - 'release-*'
+  #   paths:
+  #     - 'metadata.yaml'
 jobs:
   tag-update:
     name: Check and Update Tag

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,24 @@
 
 ## Pull Request Process
 
+### Creation of a new ACCESS-OM2 Config
+
+Config branches are entirely separate from the `main` history in this repository, save for a few files in `.github`. Note, you may need to be an Administrator to commit to `release-*` branches directly.
+
+#### If the Config is Stored in Another Repository
+
+1. Add the repository that houses the config as an upstream remote. Let's call this upstream `config`, and assume that the config is stored on the `main` branch. Let's also call the config `1deg_abc_def`.
+2. Checkout the config from one repo to this one. Run `git checkout <upstream>/<config_branch> -b release-<config_name>`. In our example, this would be `git checkout config/main -b release-1deg_abc_def`.
+3. Checkout the new branch. Run `git checkout release-<config_name>`. This would be `git checkout release-1deg_abc_def`.
+4. Copy across the required workflow files from the `main` branch. Run `git checkout main -- .github/workflows/call-*.yml .github/workflows/validate-json.yml`.
+5. Commit and push the config branch. Due to branch protection rules, you may need to be an Administrator of the repository to commit directly to a `release-*` branch.
+
+#### If the Config is Local or New
+
+1. Branch off `main` and delete everything except for `.github/workflows/call-*.yml` and `.github/workflows/validate-json.yml`.
+2. Add and commit your config files onto this branch.
+3. Commit and push the config branch. Due to branch protection rules, you may need to be an Administrator of the repository to commit directly to a `release-*` branch.
+
 ### Changes to ACCESS-OM2 Configs
 
 1. Make your changes, test them, and open a PR from the `dev-*` branch to the `release-*` branch of a particular configuration.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,15 +12,6 @@
 
 ### Changes to the CI Infrastructure
 
-Changes to the CI Infrastructure are made to the `main` branch in this repository, and then incorporated into each config branch, using the following:
-
-```bash
-git checkout main
-git subtree split -P .github -b ci
-git checkout  # some config branch
-git subtree add --squash -P .github ci  # can also subtree merge if the branch is still there locally
-# can also delete the local branch at the end with:
-git branch -D ci
-```
+Changes to the CI Infrastructure are made to the `main` branch in this repository. Config branches use the `call-*.yml` workflows to `workflow_call` the equivalent workflow that is on the `main` branch.
 
 Since the logic in the CI infrastructure is quite involved, it would be a good idea to read the [README-DEV.md](./README-DEV.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,21 +4,20 @@
 
 ### Creation of a new ACCESS-OM2 Config
 
-Config branches are entirely separate from the `main` history in this repository, save for a few files in `.github`. Note, you may need to be an Administrator to commit to `release-*` branches directly.
+Config branches are entirely separate from the `main` history in this repository, except for a few files in `.github` Note, you may need to be an Administrator to commit to `release-*` branches directly.
+
+If you are creating a new branch, and don't have config stored in another repository, just branch off `main` and delete everything except `.github/workflows/pr-1-ci.yml`, `.github/workflows/pr-3-bump-tag.yml` and `.github/workflows/validate-json.yml`, then add your config.
 
 #### If the Config is Stored in Another Repository
 
-1. Add the repository that houses the config as an upstream remote. Let's call this upstream `config`, and assume that the config is stored on the `main` branch. Let's also call the config `1deg_abc_def`.
-2. Checkout the config from one repo to this one. Run `git checkout <upstream>/<config_branch> -b release-<config_name>`. In our example, this would be `git checkout config/main -b release-1deg_abc_def`.
-3. Checkout the new branch. Run `git checkout release-<config_name>`. This would be `git checkout release-1deg_abc_def`.
-4. Copy across the required workflow files from the `main` branch. Run `git checkout main -- .github/workflows/call-*.yml .github/workflows/validate-json.yml`.
-5. Commit and push the config branch. Due to branch protection rules, you may need to be an Administrator of the repository to commit directly to a `release-*` branch.
-
-#### If the Config is Local or New
-
-1. Branch off `main` and delete everything except for `.github/workflows/call-*.yml` and `.github/workflows/validate-json.yml`.
-2. Add and commit your config files onto this branch.
-3. Commit and push the config branch. Due to branch protection rules, you may need to be an Administrator of the repository to commit directly to a `release-*` branch.
+```bash
+git remote add <config_repo> <config_repo_url>  # ex. git remote add config git@github.com/my/configs.git
+git checkout <config_repo>/<config_branch> -b release-<config_name>  # checkout config from new remote + add to branch, ex. git checkout config/main -b release-1deg_abc_def
+git checkout main -- .github/workflows/call-*.yml .github/workflows/validate-json.yml  #
+git add .
+git commit -m "Initial commit for config branch"
+git push  # might require admin permissions for pushes to release-* branch
+```
 
 ### Changes to ACCESS-OM2 Configs
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ This repository makes use of GitHub Actions to perform reproducibility checks on
 
 ### Config Branches
 
-Config branches are branches that store model configurations of the form: `release-<config>` or `dev-<config>`, for example: `release-1deg_jra55_iaf`.
+Config branches are branches that store model configurations of the form: `release-<config>` or `dev-<config>`, for example: `release-1deg_jra55_iaf`. For more information on creating your own config branches, or for understanding the PR process in this repository, see the [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ### Config Tags
 


### PR DESCRIPTION
Adding workflows to simplify future updates to CI on config branches. 

In this PR:
* Created `call-*.yml` workflows for `pr-1-ci.yml` and `pr-3-bump-tag.yml`. These workflows simply call their associated workflows that are on the main branch. 
* Updated triggers for `pr-1-ci.yml` and `pr-3-bump-tag.yml` to be `on.workflow_call`
* Updated info in `CONTRIBUTING.md` regarding how to create new config branches from scratch
* Updated `README.md` by adding a link to the above

Closes #24