### PR TITLE
Add restart reproducibility test into repro CI 

### DIFF
--- a/test/models/model.py
+++ b/test/models/model.py
@@ -1,12 +1,15 @@
 """Generic Model class"""
 from pathlib import Path
+from typing import Dict, Any
 
 
 class Model(object):
     def __init__(self, experiment):
         self.experiment = experiment
 
-    def extract_checksums(self, output_directory: Path = None):
+    def extract_checksums(self,
+                          output_directory: Path,
+                          schema_version: str):
         """Extract checksums from output directory"""
         raise NotImplementedError
 
@@ -19,4 +22,12 @@ class Model(object):
 
     def output_exists(self):
         """Check for existing output files"""
+        raise NotImplementedError
+
+    def check_checksums_over_restarts(self,
+                                      long_run_checksum,
+                                      short_run_checksum_0,
+                                      short_run_checksum_1) -> bool:
+        """Compare a checksums from a long run (e.g. 2 days) against
+        checksums from 2 short runs (e.g. 1 day)"""
         raise NotImplementedError

--- a/test/test_bit_reproducibility.py
+++ b/test/test_bit_reproducibility.py
@@ -74,8 +74,7 @@ class TestBitReproducibility():
 
         assert produced == expected
 
-    @pytest.mark.slow
-    @pytest.mark.skip(reason="TODO:Check checksum comparision across restarts")
+    @pytest.mark.checksum
     def test_restart_repro(self, output_path: Path, control_path: Path):
         """
         Test that a run reproduces across restarts.
@@ -104,16 +103,15 @@ class TestBitReproducibility():
         checksums_1d_0 = exp_2x1day.extract_checksums()
         checksums_1d_1 = exp_2x1day.extract_checksums(exp_2x1day.output001)
 
-        # Adding checksums over two outputs might need to be model specific?
-        checksums_2x1d = checksums_1d_0['output'] + checksums_1d_1['output']
-
         checksums_2d = exp_2day.extract_checksums()
 
-        matching_checksums = True
-        for item in checksums_2d['output']:
-            if item not in checksums_2x1d:
-                print("Unequal checksum:", item)
-                matching_checksums = False
+        # Use model specific comparision method for checksums
+        model = exp_2day.model
+        matching_checksums = model.check_checksums_over_restarts(
+            long_run_checksum=checksums_2d,
+            short_run_checksum_0=checksums_1d_0,
+            short_run_checksum_1=checksums_1d_1
+        )
 
         if not matching_checksums:
             # Write checksums out to file


### PR DESCRIPTION
Enable restart reproducibility checksum checks - as detailed in #11 

I've added the marker `checksum` to the restart checksum tests, added a model-specific checksum comparison method (as format of checksums may different depending on the model). 

For access-om2 model, it is basically doing the same check as before, i.e any field and checksum value in the `2-day` model run is in either of the first or second `1 day` model runs. 

I have manually tested it with a `1deg_jra55_ryf` configuration where I’ve just updated the executables paths to point to the corresponding pre-release locations with the fix - [config.yaml used](https://gist.github.com/jo-basevi/734d0c3538ad91a61a985a1bed6a2c2e).  Currently it's failing the `test_bit_repro_historical` test - so the checksums ([historical-3hr-checksum.json](https://gist.github.com/jo-basevi/c7b1eefa25b2d990080e779c732c87e0)) are different to checksums saved on the release configuration branch, is that to be expected?

Also have noticed the tests are taking ages to run - as it's mostly waiting in queues - wondered whether its worth dropping the qsub walltime and memory for short tests. But that might not be the best idea as different configurations may need varying resources.. 

With adding the `checksum` marker, this pytest will be run as part of the reproducibility checks. It outputs some checksum files if it fails, I haven't added them to the `checksum` output sub-directory as that is `rsync`ed to github. Should it be `rsync`ed to github? I don't think it should be added to the `testing/checksum` on each configuration branch. Another todo, is maybe update the reproducibility fail messages in the CI as the test can fail in either the historical checksums or the restart test.