### PR TITLE
Concatenate CICE daily output

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -92,7 +92,9 @@ env:
 platform:
     nodesize: 48
 
-# sweep and resubmit on specific errors - see https://github.com/payu-org/payu/issues/241#issuecomment-610739771
 userscripts:
+    # sweep and resubmit on specific errors - see https://github.com/payu-org/payu/issues/241#issuecomment-610739771
     error: tools/resub.sh
     run: rm -f resubmit.count
+    # combine cice daily history files into one file per month
+    archive: tools/concat_ice_daily.sh 

--- a/config.yaml
+++ b/config.yaml
@@ -97,4 +97,8 @@ userscripts:
     error: tools/resub.sh
     run: rm -f resubmit.count
     # combine cice daily history files into one file per month
-    archive: tools/concat_ice_daily.sh 
+    archive: tools/concat_ice_daily.sh
+    
+modules:
+  load:
+    - nco/5.0.5

--- a/tools/concat_ice_daily.sh
+++ b/tools/concat_ice_daily.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+#concatenate sea-ice daily output
+#script inspired from https://github.com/COSIMA/1deg_jra55_ryf/blob/master/sync_data.sh#L87-L108
+
+for d in archive/output*/ice/OUTPUT; do
+    for f in $d/iceh.????-??-01.nc; do
+        if [[ ! -f ${f/-01.nc/-IN-PROGRESS} ]] && [[ ! -f ${f/-01.nc/-daily.nc} ]];
+        then
+            touch ${f/-01.nc/-IN-PROGRESS}
+            echo "doing ncrcat -O -L 5 -4 ${f/-01.nc/-??.nc} ${f/-01.nc/-daily.nc}"
+            ${PAYU_PATH}/ncrcat -O -L 5 -4 ${f/-01.nc/-??.nc} ${f/-01.nc/-daily.nc} && chmod g+r ${f/-01.nc/-daily.nc} && rm ${f/-01.nc/-IN-PROGRESS}
+            if [[ ! -f ${f/-01.nc/-IN-PROGRESS} ]] && [[ -f ${f/-01.nc/-daily.nc} ]];
+            then
+                for daily in ${f/-01.nc/-??.nc}
+                do
+                    # mv $daily $daily-DELETE  # rename individual daily files - user to delete
+                    rm $daily
+                done
+            else
+                rm ${f/-01.nc/-IN-PROGRESS}
+            fi
+        fi
+    done
+done

--- a/tools/concat_ice_daily.sh
+++ b/tools/concat_ice_daily.sh
@@ -1,24 +1,18 @@
-#!/bin/bash
+#!/usr/bin/bash
 #concatenate sea-ice daily output
 #script inspired from https://github.com/COSIMA/1deg_jra55_ryf/blob/master/sync_data.sh#L87-L108
 
-for d in archive/output*/ice/OUTPUT; do
-    for f in $d/iceh.????-??-01.nc; do
-        if [[ ! -f ${f/-01.nc/-IN-PROGRESS} ]] && [[ ! -f ${f/-01.nc/-daily.nc} ]];
-        then
-            touch ${f/-01.nc/-IN-PROGRESS}
-            echo "doing ncrcat -O -L 5 -4 ${f/-01.nc/-??.nc} ${f/-01.nc/-daily.nc}"
-            ${PAYU_PATH}/ncrcat -O -L 5 -4 ${f/-01.nc/-??.nc} ${f/-01.nc/-daily.nc} && chmod g+r ${f/-01.nc/-daily.nc} && rm ${f/-01.nc/-IN-PROGRESS}
-            if [[ ! -f ${f/-01.nc/-IN-PROGRESS} ]] && [[ -f ${f/-01.nc/-daily.nc} ]];
-            then
-                for daily in ${f/-01.nc/-??.nc}
-                do
-                    # mv $daily $daily-DELETE  # rename individual daily files - user to delete
-                    rm $daily
-                done
-            else
-                rm ${f/-01.nc/-IN-PROGRESS}
-            fi
-        fi
-    done
+out_dir=$(ls -td archive/output??? | head -1)/ice/OUTPUT #latest output dir only
+
+for f in $out_dir/iceh.????-??-01.nc; do
+    #concat daily files for this month
+    echo "doing ncrcat -O -L 5 -4 ${f/-01.nc/-??.nc} ${f/-01.nc/-daily.nc}"
+    ncrcat -O -L 5 -4 ${f/-01.nc/-??.nc} ${f/-01.nc/-daily.nc} 
+    
+    if [[ $? == 0 ]]; # ncrcat succeeded
+    then 
+        #set permissions and delete indidual dailys
+        chmod g+r ${f/-01.nc/-daily.nc}
+        rm ${f/-01.nc/-??.nc}
+    fi
 done


### PR DESCRIPTION
Add script to concatenate daily cice output into one file per month (still containing daily data) and delete the individual daily files. This relies on adding nco to the payu environment per https://github.com/ACCESS-NRI/payu-condaenv/pull/24.

Following Aidan's suggestion, the script is taken from https://github.com/COSIMA/1deg_jra55_ryf/blob/master/sync_data.sh#L87-L108, and on that basis I haven't tested beyond checking that it concatenates data.

The only change I made was change the netcdf output type to -4 (netcdf4) instead of -7 (netcdf4_classic).

Looking at ncdump of output looks correct, i.e. it shows time and time bound dimensions of length 31 days for January.

Maybe @aekiss would like to review too?