### PR TITLE
Add pytests and CI for simple configuration checks

### DIFF
--- a/.github/workflows/call-pr-1-ci.yml
+++ b/.github/workflows/call-pr-1-ci.yml
@@ -12,7 +12,6 @@ on:
       - tools/**
       - doc/**
       - .*
-      - metadata.yaml
       - README.md
 jobs:
   call:

--- a/.github/workflows/pr-1-ci.yml
+++ b/.github/workflows/pr-1-ci.yml
@@ -5,7 +5,7 @@ on:
       qa-pytest-markers:
         type: string
         required: false
-        default: config or metadata
+        default: config
         description: List of markers for the pytest QA CI checks
       qa-pytest-add-model-markers:
         type: boolean
@@ -121,23 +121,11 @@ jobs:
         working-directory: ./pytest
         run: pip install -r ./test/requirements.txt
 
-      - name: Infer Model-Specific Checks
-        id: model
-        if: inputs.qa-pytest-add-model-markers
-        run:
-          if [[ "${{ contains(github.base_ref, 'bgc') }}" == "true" ]]; then
-            echo "Using model-specific access_om2_bgc pytest marker"
-            echo "markers=access_om2_bgc" >> $GITHUB_OUTPUT
-          else
-            echo "Using model-specific access_om2 pytest marker"
-            echo "markers=access_om2" >> $GITHUB_OUTPUT
-          fi
-
       - name: Get Final List of Markers
         id: pytest-markers
         run: |
           if [[ ${{ inputs.qa-pytest-add-model-markers }} == "true" ]]; then
-            echo "markers=${{ inputs.qa-pytest-markers }} or ${{ steps.model.outputs.markers }}" >> $GITHUB_OUTPUT
+            echo "markers=${{ inputs.qa-pytest-markers }} or access_om2" >> $GITHUB_OUTPUT
           else
             echo "markers=${{ inputs.qa-pytest-markers }}" >> $GITHUB_OUTPUT
           fi
@@ -147,10 +135,9 @@ jobs:
         # the next step speak to the state of the testing
         continue-on-error: true
         working-directory: ./pr
-        # TODO: Call `pytest ../pytest/test` once we can factor out the tests that require 'f90nml'
         run: |
           echo "Running pytest using '-m ${{ steps.pytest-markers.outputs.markers }}'"
-          pytest ../pytest/test/test_config.py \
+          pytest ../pytest/test \
             -m '${{ steps.pytest-markers.outputs.markers }}' \
             --junitxml=./test_report.xml
 

--- a/.github/workflows/pr-1-ci.yml
+++ b/.github/workflows/pr-1-ci.yml
@@ -35,10 +35,13 @@ jobs:
 
   branch-check:
     name: PR Source Branch Check
+    # This check is used as a precursor to any repro-ci checks - which are only fired
+    # on dev-* -> release-* PRs.
     # This check is run to confirm that the source branch is of the form `dev-<config>`
     # and the target branch is of the form `release-<config>`. We are being especially
     # concerned with branch names because deployment to GitHub Environments can only
-    # be done on source branches with a certain pattern. See #20.
+    # be done on source branches with a certain pattern. See ACCESS-NRI/access-om2-configs#20.
+    if: startsWith(github.base_ref, 'dev-')
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -82,8 +85,60 @@ jobs:
             Rename the Source branch or check the Target branch, and try again.
         run: gh pr comment --body '${{ env.BODY }}'
 
+  simple-ci:
+    # Run quick, non-HPC tests on the runner.
+    name: Simple CI checks
+    needs:
+      - commit-check
+      - branch-check
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+    steps:
+      - name: Checkout PR ${{ github.event.action.pull_request.number }}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.base_ref }}
+          path: pr
+
+      - name: Checkout Tests
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          path: pytest
+
+      - name: Setup Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
+          cache: pip
+
+      - name: Install requirements.txt
+        run: pip install -r ./pytest/test/requirements.txt
+
+      - name: Invoke Simple CI Pytests
+        # We continue on error because we will left the checks generated in
+        # the next step speak to the state of the testing
+        continue-on-error: true
+        run: |
+          cd pr
+          pytest ../pytest/test/test_config.py \
+            -m 'config' \
+            --junitxml=./test_report.xml
+
+      - name: Parse Test Report
+        id: tests
+        uses: EnricoMi/publish-unit-test-result-action/composite@e780361cd1fc1b1a170624547b3ffda64787d365  #v2.12.0
+        with:
+          files: ./pr/test_report.xml
+          comment_mode: off
+          check_run: true
+          compare_to_earlier_commit: false
+          report_individual_runs: true
+          report_suite_logs: any
+
   repro-ci:
-    # run the given config on the deployment GitHub Environment (`environment-name`) and
+    # Run the given config on the deployment GitHub Environment (`environment-name`) and
     # upload the checksums and test details
     needs:
       - commit-check

--- a/.github/workflows/pr-1-ci.yml
+++ b/.github/workflows/pr-1-ci.yml
@@ -143,7 +143,7 @@ jobs:
           fi
 
       - name: Invoke Simple CI Pytests
-        # We continue on error because we will left the checks generated in
+        # We continue on error because we will let the checks generated in
         # the next step speak to the state of the testing
         continue-on-error: true
         working-directory: ./pr

--- a/.github/workflows/pr-1-ci.yml
+++ b/.github/workflows/pr-1-ci.yml
@@ -1,6 +1,22 @@
 name: PR Checks
 on:
   workflow_call:
+    inputs:
+      qa-pytest-markers:
+        type: string
+        required: false
+        default: config or metadata
+        description: List of markers for the pytest QA CI checks
+      qa-pytest-add-model-markers:
+        type: boolean
+        required: false
+        default: false
+        description: Whether to run model-specific tests
+      repro-pytest-markers:
+        type: string
+        required: false
+        default: checksum
+        description: List of markers for the pytest repro CI checks
   # Workflows that call this workflow use the following triggers:
   # pull_request:
   #   branches:
@@ -85,9 +101,9 @@ jobs:
             Rename the Source branch or check the Target branch, and try again.
         run: gh pr comment --body '${{ env.BODY }}'
 
-  simple-ci:
+  qa-ci:
     # Run quick, non-HPC tests on the runner.
-    name: Simple CI checks
+    name: QA CI Checks
     needs:
       - commit-check
       - branch-check
@@ -114,16 +130,38 @@ jobs:
           cache: pip
 
       - name: Install requirements.txt
-        run: pip install -r ./pytest/test/requirements.txt
+        working-directory: ./pytest
+        run: pip install -r ./test/requirements.txt
+
+      - name: Infer Model-Specific Checks
+        id: model
+        if: inputs.qa-pytest-add-model-markers
+        run:
+          if [[ "${{ contains(github.base_ref, 'bgc') }}" == "true" ]]; then
+            echo "Using model-specific access_om2_bgc pytest marker"
+            echo "markers=access_om2_bgc" >> $GITHUB_OUTPUT
+          else
+            echo "Using model-specific access_om2 pytest marker"
+            echo "markers=access_om2" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Get Final List of Markers
+        id: pytest
+        run: |
+          if [[ ${{ inputs.qa-pytest-add-model-markers }} == "true" ]]; then
+            echo "markers=${{ inputs.qa-pytest-markers }} or ${{ steps.model.outputs.markers }}" >> $GITHUB_OUTPUT
+          else
+            echo "markers=${{ inputs.qa-pytest-markers }}" >> $GITHUB_OUTPUT
+          fi
 
       - name: Invoke Simple CI Pytests
         # We continue on error because we will left the checks generated in
         # the next step speak to the state of the testing
         continue-on-error: true
         run: |
-          cd pr
+          echo "Running pytest using '-m ${{ steps.pytest.outputs.markers }}'"
           pytest ../pytest/test/test_config.py \
-            -m 'config' \
+            -m '${{ steps.pytest.outputs.markers }}' \
             --junitxml=./test_report.xml
 
       - name: Parse Test Report
@@ -149,7 +187,7 @@ jobs:
       model-name: access-om2
       environment-name: Gadi
       config-tag: ${{ github.head_ref }}
-      test-markers: checksum
+      test-markers: ${{ inputs.repro-pytest-markers }}
     secrets: inherit
     permissions:
       contents: write

--- a/.github/workflows/pr-1-ci.yml
+++ b/.github/workflows/pr-1-ci.yml
@@ -28,7 +28,6 @@ on:
   #     - tools/**
   #     - doc/**
   #     - .*
-  #     - metadata.yaml
   #     - README.md
 jobs:
   commit-check:

--- a/.github/workflows/pr-1-ci.yml
+++ b/.github/workflows/pr-1-ci.yml
@@ -278,7 +278,7 @@ jobs:
           BODY: |
             :white_check_mark: The Bitwise Reproducibility check succeeded when comparing against `${{ needs.check-checksum.outputs.compared-checksum-version }}` for this `Release` config. :white_check_mark:
             For further information, the experiment can be found on Gadi at ${{ needs.repro-ci.outputs.experiment-location }}, and the test results at ${{ needs.check-checksum.outputs.check-run-url }}.
-            You must bump the minor version of `access-om2-configs` - to bump the version, comment `!bump minor`. The meaning of these version bumps is explained in the README.md, under `Config Tags`.
+            You must bump the minor version of `access-om2-configs` - to bump the version, comment `!bump minor` or modify the `version` in `metadata.yaml`. The meaning of these version bumps is explained in the README.md, under `Config Tags`.
         run: gh pr comment --body '${{ env.BODY }}'
 
       - name: Successful Dev Comment
@@ -295,7 +295,7 @@ jobs:
           BODY: |
             :x: The Bitwise Reproducibility check failed when comparing against `${{ needs.check-checksum.outputs.compared-checksum-version }}` for this `Release` config. :x:
             For further information, the experiment can be found on Gadi at ${{ needs.repro-ci.outputs.experiment-location }}, and the test results at ${{ needs.check-checksum.outputs.check-run-url }}.
-            You must bump the major version of `access-om2-configs` before this PR is merged to account for this - to bump the version, comment `!bump major`. The meaning of these version bumps is explained in the README.md, under `Config Tags`.
+            You must bump the major version of `access-om2-configs` before this PR is merged to account for this - to bump the version, comment `!bump major`or modify the `version` in `metadata.yaml`. The meaning of these version bumps is explained in the README.md, under `Config Tags`.
         run: gh pr comment --body '${{ env.BODY }}'
 
       - name: Failed Dev Comment

--- a/.github/workflows/pr-1-ci.yml
+++ b/.github/workflows/pr-1-ci.yml
@@ -57,7 +57,9 @@ jobs:
     # and the target branch is of the form `release-<config>`. We are being especially
     # concerned with branch names because deployment to GitHub Environments can only
     # be done on source branches with a certain pattern. See ACCESS-NRI/access-om2-configs#20.
-    if: startsWith(github.base_ref, 'release-') && startsWith(github.head_ref, 'dev-')
+    if: needs.commit-check.outputs.authorship != vars.GH_ACTIONS_BOT_GIT_USER_NAME && startsWith(github.base_ref, 'release-') && startsWith(github.head_ref, 'dev-')
+    needs:
+      - commit-check
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -92,6 +94,7 @@ jobs:
     name: QA CI Checks
     needs:
       - commit-check
+    if: needs.commit-check.outputs.authorship != vars.GH_ACTIONS_BOT_GIT_USER_NAME
     runs-on: ubuntu-latest
     permissions:
       checks: write
@@ -168,7 +171,7 @@ jobs:
     needs:
       - commit-check
       - branch-check
-    if: needs.commit-check.outputs.authorship != 'github-actions' && needs.branch-check.result == 'success'
+    if: needs.commit-check.outputs.authorship != vars.GH_ACTIONS_BOT_GIT_USER_NAME && needs.branch-check.result == 'success'
     uses: access-nri/reproducibility/.github/workflows/checks.yml@main
     with:
       model-name: access-om2

--- a/.github/workflows/pr-1-ci.yml
+++ b/.github/workflows/pr-1-ci.yml
@@ -139,6 +139,7 @@ jobs:
           echo "Running pytest using '-m ${{ steps.pytest-markers.outputs.markers }}'"
           pytest ../pytest/test \
             -m '${{ steps.pytest-markers.outputs.markers }}' \
+            --target-branch '${{ github.base_ref }}' \
             --junitxml=./test_report.xml
 
       - name: Parse Test Report

--- a/.github/workflows/pr-1-ci.yml
+++ b/.github/workflows/pr-1-ci.yml
@@ -10,7 +10,7 @@ on:
       qa-pytest-add-model-markers:
         type: boolean
         required: false
-        default: false
+        default: true
         description: Whether to run model-specific tests
       repro-pytest-markers:
         type: string
@@ -57,7 +57,7 @@ jobs:
     # and the target branch is of the form `release-<config>`. We are being especially
     # concerned with branch names because deployment to GitHub Environments can only
     # be done on source branches with a certain pattern. See ACCESS-NRI/access-om2-configs#20.
-    if: startsWith(github.base_ref, 'dev-')
+    if: startsWith(github.base_ref, 'dev-') && startsWith(github.head_ref, 'release-')
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -106,7 +106,6 @@ jobs:
     name: QA CI Checks
     needs:
       - commit-check
-      - branch-check
     runs-on: ubuntu-latest
     permissions:
       checks: write
@@ -114,7 +113,7 @@ jobs:
       - name: Checkout PR ${{ github.event.action.pull_request.number }}
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.base_ref }}
+          ref: ${{ github.head_ref }}
           path: pr
 
       - name: Checkout Tests
@@ -146,7 +145,7 @@ jobs:
           fi
 
       - name: Get Final List of Markers
-        id: pytest
+        id: pytest-markers
         run: |
           if [[ ${{ inputs.qa-pytest-add-model-markers }} == "true" ]]; then
             echo "markers=${{ inputs.qa-pytest-markers }} or ${{ steps.model.outputs.markers }}" >> $GITHUB_OUTPUT
@@ -158,10 +157,12 @@ jobs:
         # We continue on error because we will left the checks generated in
         # the next step speak to the state of the testing
         continue-on-error: true
+        working-directory: ./pr
+        # TODO: Call `pytest ../pytest/test` once we can factor out the tests that require 'f90nml'
         run: |
-          echo "Running pytest using '-m ${{ steps.pytest.outputs.markers }}'"
+          echo "Running pytest using '-m ${{ steps.pytest-markers.outputs.markers }}'"
           pytest ../pytest/test/test_config.py \
-            -m '${{ steps.pytest.outputs.markers }}' \
+            -m '${{ steps.pytest-markers.outputs.markers }}' \
             --junitxml=./test_report.xml
 
       - name: Parse Test Report

--- a/.github/workflows/pr-1-ci.yml
+++ b/.github/workflows/pr-1-ci.yml
@@ -148,6 +148,7 @@ jobs:
           files: ./pr/test_report.xml
           comment_mode: off
           check_run: true
+          check_name: QA Test Results
           compare_to_earlier_commit: false
           report_individual_runs: true
           report_suite_logs: any
@@ -208,6 +209,7 @@ jobs:
           files: ${{ env.TESTING_LOCAL_LOCATION }}/checksum/test_report.xml
           comment_mode: off
           check_run: true
+          check_name: Repro Test Results
           compare_to_earlier_commit: false
           report_individual_runs: true
           report_suite_logs: any

--- a/.github/workflows/pr-1-ci.yml
+++ b/.github/workflows/pr-1-ci.yml
@@ -57,7 +57,7 @@ jobs:
     # and the target branch is of the form `release-<config>`. We are being especially
     # concerned with branch names because deployment to GitHub Environments can only
     # be done on source branches with a certain pattern. See ACCESS-NRI/access-om2-configs#20.
-    if: startsWith(github.base_ref, 'dev-') && startsWith(github.head_ref, 'release-')
+    if: startsWith(github.base_ref, 'release-') && startsWith(github.head_ref, 'dev-')
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -65,20 +65,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
-
-      - name: Check Source
-        run: |
-          if [[ "${{ startsWith(github.head_ref, 'dev-') }}" == "false" ]]; then
-            echo "::error::Source branch ${{ github.head_ref }} doesn't match 'dev-*'"
-            exit 1
-          fi
-
-      - name: Check Target
-        run: |
-          if [[ "${{ startsWith(github.base_ref, 'release-') }}" == "false" ]]; then
-            echo "::error::Target branch ${{ github.base_ref }} doesn't match 'release-*'"
-            exit 1
-          fi
 
       - name: Compare Source and Target Config Names
         # In this step, we cut the 'dev-' and 'release-' to compare config names directly.
@@ -96,7 +82,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           BODY: |
-            :x: Automated testing cannot be run on this branch :x:
+            :x: Automated Reproducibility testing cannot be run on this branch :x:
             Source and Target branches must be of the form `dev-<config>` and `release-<config>` respectively, and `<config>` must match between them.
             Rename the Source branch or check the Target branch, and try again.
         run: gh pr comment --body '${{ env.BODY }}'

--- a/.github/workflows/pr-1-ci.yml
+++ b/.github/workflows/pr-1-ci.yml
@@ -224,6 +224,38 @@ jobs:
             echo "result=pass" >> $GITHUB_OUTPUT
           fi
 
+  bump-check:
+    name: Version Bump Check
+    # Check that the `.version` in the metadata.yaml has been modified in
+    # this PR.
+    needs:
+      - repro-ci
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR Target
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.base_ref }}
+          path: target
+
+      - name: Checkout PR Source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          path: source
+
+      - name: Modification Check
+        run: |
+          target=$(yq e '.version' ./target/metadata.yaml)
+          source=$(yq e '.version' ./source/metadata.yaml)
+
+          if [[ "${source}" != "${target}" && "${source}" != "null" ]]; then
+            echo "::notice::The version has been modified to ${target}. Merging is now availible"
+          else
+            echo "::error::The version has not been modified in this PR. Merging is disallowed until an appropriate '!bump' is issued"
+            exit 1
+          fi
+
   result:
     name: Repro Result Notifier
     # Notify the PR of the result of the Repro check
@@ -247,7 +279,7 @@ jobs:
           BODY: |
             :white_check_mark: The Bitwise Reproducibility check succeeded when comparing against `${{ needs.check-checksum.outputs.compared-checksum-version }}` for this `Release` config. :white_check_mark:
             For further information, the experiment can be found on Gadi at ${{ needs.repro-ci.outputs.experiment-location }}, and the test results at ${{ needs.check-checksum.outputs.check-run-url }}.
-            Consider bumping the minor version of `access-om2-configs` - to bump the version, comment `!bump minor`. The meaning of these version bumps is explained in the README.md, under `Config Tags`.
+            You must bump the minor version of `access-om2-configs` - to bump the version, comment `!bump minor`. The meaning of these version bumps is explained in the README.md, under `Config Tags`.
         run: gh pr comment --body '${{ env.BODY }}'
 
       - name: Successful Dev Comment

--- a/.github/workflows/pr-1-ci.yml
+++ b/.github/workflows/pr-1-ci.yml
@@ -273,7 +273,7 @@ jobs:
           ref: ${{ github.head_ref }}
 
       - name: Successful Release Comment
-        if: needs.check-checksum.outputs.result == 'pass' && startsWith(github.base_ref, 'release-')
+        if: needs.check-checksum.outputs.result == 'pass'
         env:
           BODY: |
             :white_check_mark: The Bitwise Reproducibility check succeeded when comparing against `${{ needs.check-checksum.outputs.compared-checksum-version }}` for this `Release` config. :white_check_mark:
@@ -281,27 +281,11 @@ jobs:
             You must bump the minor version of `access-om2-configs` - to bump the version, comment `!bump minor` or modify the `version` in `metadata.yaml`. The meaning of these version bumps is explained in the README.md, under `Config Tags`.
         run: gh pr comment --body '${{ env.BODY }}'
 
-      - name: Successful Dev Comment
-        if: needs.check-checksum.outputs.result == 'pass' && startsWith(github.base_ref, 'dev-')
-        env:
-          BODY: |
-            :white_check_mark: The Bitwise Reproducibility check succeeded when comparing against `${{ needs.check-checksum.outputs.compared-checksum-version }}` for this `Dev` config. :white_check_mark:
-            For further information, the experiment can be found on Gadi at ${{ needs.repro-ci.outputs.experiment-location }}, and the test results at ${{ needs.check-checksum.outputs.check-run-url }}.
-        run: gh pr comment --body '${{ env.BODY }}'
-
       - name: Failed Release Comment
-        if: needs.check-checksum.outputs.result == 'fail' && startsWith(github.base_ref, 'release-')
+        if: needs.check-checksum.outputs.result == 'fail'
         env:
           BODY: |
             :x: The Bitwise Reproducibility check failed when comparing against `${{ needs.check-checksum.outputs.compared-checksum-version }}` for this `Release` config. :x:
             For further information, the experiment can be found on Gadi at ${{ needs.repro-ci.outputs.experiment-location }}, and the test results at ${{ needs.check-checksum.outputs.check-run-url }}.
             You must bump the major version of `access-om2-configs` before this PR is merged to account for this - to bump the version, comment `!bump major`or modify the `version` in `metadata.yaml`. The meaning of these version bumps is explained in the README.md, under `Config Tags`.
-        run: gh pr comment --body '${{ env.BODY }}'
-
-      - name: Failed Dev Comment
-        if: needs.check-checksum.outputs.result == 'fail' && startsWith(github.base_ref, 'dev-')
-        env:
-          BODY: |
-            :warning: The Bitwise Reproducibility check failed when comparing against `${{ needs.check-checksum.outputs.compared-checksum-version }}` for this `Dev` config. :warning:
-            For further information, the experiment can be found on Gadi at ${{ needs.repro-ci.outputs.experiment-location }}, and the test results at ${{ needs.check-checksum.outputs.check-run-url }}.
         run: gh pr comment --body '${{ env.BODY }}'

--- a/.github/workflows/pr-2-confirm.yml
+++ b/.github/workflows/pr-2-confirm.yml
@@ -118,8 +118,8 @@ jobs:
 
       - name: Commit and Push Updates
         run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
+          git config user.name ${{ vars.GH_ACTIONS_BOT_GIT_USER_NAME }}
+          git config user.email ${{ vars.GH_ACTIONS_BOT_GIT_USER_EMAIL }}
 
           if [[ "${{ needs.bump-version.outputs.type }}" == "minor" ]]; then
             git commit -am "Bumped version to ${{ needs.bump-version.outputs.after }} as part of ${{ env.RUN_URL }}"

--- a/.github/workflows/pr-2-confirm.yml
+++ b/.github/workflows/pr-2-confirm.yml
@@ -58,6 +58,12 @@ jobs:
         id: bump
         run: |
           version=$(yq '.version' metadata.yaml)
+
+          if [[ "${version}" == "null" ]]; then
+            echo "before=null" >> $GITHUB_OUTPUT
+            echo "after=1.0" >> $GITHUB_OUTPUT
+          fi
+
           regex="([0-9]+)\.([0-9]+)"
           if [[ $version =~ $regex ]]; then
             major_version="${BASH_REMATCH[1]}"

--- a/.github/workflows/schedule-2-start.yml
+++ b/.github/workflows/schedule-2-start.yml
@@ -80,7 +80,7 @@ jobs:
       MODEL_URL: https://github.com/ACCESS-NRI/access-om2
       CONFIG: access-om2-configs
       CONFIG_URL: https://github.com/ACCESS-NRI/access-om2-configs
-      TAG_URL: https://github.com/ACCESS-NRI/access-om2-configs/tags/${{ needs.check-checksum.outputs.compared-checksum-version }}
+      TAG_URL: https://github.com/ACCESS-NRI/access-om2-configs/releases/tag/${{ needs.check-checksum.outputs.compared-checksum-version }}
       RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
       - name: Create issue

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -58,6 +58,9 @@ def pytest_configure(config):
         "markers", "slow: mark tests as slow (deselect with '-m \"not slow\"')"
     )
     config.addinivalue_line(
+        "markers", "test: mark tests as testing test functionality"
+    )
+    config.addinivalue_line(
         "markers", "checksum: mark tests to run as part of reproducibility CI tests"
     )
     config.addinivalue_line(

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -41,6 +41,7 @@ def checksum_path(request, control_path):
 
 @pytest.fixture(scope="session")
 def metadata(control_path: Path):
+    """Read the metadata file in the control directory"""
     metadata_path = control_path / 'metadata.yaml'
     with open(metadata_path) as f:
         content = yaml.safe_load(f)
@@ -49,10 +50,19 @@ def metadata(control_path: Path):
 
 @pytest.fixture(scope="session")
 def config(control_path: Path):
+    """Read the config file in the control directory"""
     config_path = control_path / 'config.yaml'
     with open(config_path) as f:
         config_content = yaml.safe_load(f)
     return config_content
+
+
+@pytest.fixture(scope="session")
+def target_branch(request):
+    """Set the target branch - i.e., the branch the configuration will be
+    merged into. This used is to infer configuration information, if the
+    configuration branches follow a common naming scheme (e.g. ACCESS-OM2)"""
+    return request.config.getoption('--target-branch')
 
 
 # Set up command line options and default for directory paths
@@ -69,6 +79,10 @@ def pytest_addoption(parser):
     parser.addoption("--checksum-path",
                      action="store",
                      help="Specify the checksum file to compare against")
+    
+    parser.addoption("--target-branch",
+                     action="store",
+                     help="Specify the target branch name")
 
 
 def pytest_configure(config):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -61,10 +61,10 @@ def pytest_configure(config):
         "markers", "checksum: mark tests to run as part of reproducibility CI tests"
     )
     config.addinivalue_line(
-        "markers", "config: mark as configuration tests (e.g. config.yaml)"
+        "markers", "config: mark as configuration tests in quick CI checks"
     )
     config.addinivalue_line(
-        "markers", "metadata: mark as metadata tests (e.g. metadata.yaml)"
+        "markers", "metadata: mark as metadata tests in quick CI checks"
     )
     config.addinivalue_line(
         "markers", "access_om2: mark as access-om2 specific tests"
@@ -73,12 +73,5 @@ def pytest_configure(config):
         "markers", "access_om2_bgc: mark as access-om2-bgc specific tests"
     )
     config.addinivalue_line(
-        "markers", "test: mark tests as testing test functionality"
-    )
-    config.addinivalue_line(
-        "markers", "config: mark tests as dealing with quick model configuration checks"
-    )
-    config.addinivalue_line(
-        # FIXME: What is this marker about?
-        "markers", "highres: mark tests as dealing with <something>"
+        "markers", "highres: mark tests as high resolution model configuration tests"
     )

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -63,3 +63,10 @@ def pytest_configure(config):
     config.addinivalue_line(
         "markers", "test: mark tests as testing test functionality"
     )
+    config.addinivalue_line(
+        "markers", "config: mark tests as dealing with quick model configuration checks"
+    )
+    config.addinivalue_line(
+        # FIXME: What is this marker about?
+        "markers", "highres: mark tests as dealing with <something>"
+    )

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -61,6 +61,18 @@ def pytest_configure(config):
         "markers", "checksum: mark tests to run as part of reproducibility CI tests"
     )
     config.addinivalue_line(
+        "markers", "config: mark as configuration tests (e.g. config.yaml)"
+    )
+    config.addinivalue_line(
+        "markers", "metadata: mark as metadata tests (e.g. metadata.yaml)"
+    )
+    config.addinivalue_line(
+        "markers", "access_om2: mark as access-om2 specific tests"
+    )
+    config.addinivalue_line(
+        "markers", "access_om2_bgc: mark as access-om2-bgc specific tests"
+    )
+    config.addinivalue_line(
         "markers", "test: mark tests as testing test functionality"
     )
     config.addinivalue_line(

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -82,8 +82,8 @@ def pytest_configure(config):
         "markers", "checksum: mark tests to run as part of reproducibility CI tests"
     )
     config.addinivalue_line(
-        "markers", "config: mark as configuration tests in quick CI checks"
+        "markers", "config: mark as configuration tests in quick QA CI checks"
     )
     config.addinivalue_line(
-        "markers", "access_om2: mark as access-om2 specific tests"
+        "markers", "access_om2: mark as access-om2 specific tests in quick QA CI checks"
     )

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2,6 +2,8 @@ import os
 import pytest
 from pathlib import Path
 
+import yaml
+
 
 @pytest.fixture(scope="session")
 def output_path(request):
@@ -37,6 +39,22 @@ def checksum_path(request, control_path):
     return Path(path)
 
 
+@pytest.fixture(scope="session")
+def metadata(control_path: Path):
+    metadata_path = control_path / 'metadata.yaml'
+    with open(metadata_path) as f:
+        content = yaml.safe_load(f)
+    return content
+
+
+@pytest.fixture(scope="session")
+def config(control_path: Path):
+    config_path = control_path / 'config.yaml'
+    with open(config_path) as f:
+        config_content = yaml.safe_load(f)
+    return config_content
+
+
 # Set up command line options and default for directory paths
 def pytest_addoption(parser):
     """Attaches optional command line arguments"""
@@ -67,14 +85,5 @@ def pytest_configure(config):
         "markers", "config: mark as configuration tests in quick CI checks"
     )
     config.addinivalue_line(
-        "markers", "metadata: mark as metadata tests in quick CI checks"
-    )
-    config.addinivalue_line(
         "markers", "access_om2: mark as access-om2 specific tests"
-    )
-    config.addinivalue_line(
-        "markers", "access_om2_bgc: mark as access-om2-bgc specific tests"
-    )
-    config.addinivalue_line(
-        "markers", "highres: mark tests as high resolution model configuration tests"
     )

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,5 +1,5 @@
 pytest==8.0.1
 jsonschema==4.21.1
-requests==2.31.0
-PyYAML==6.0.1
-f90nml==1.4.4
+requests
+PyYAML
+f90nml>=0.16

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -2,3 +2,4 @@ pytest==8.0.1
 jsonschema==4.21.1
 requests==2.31.0
 PyYAML==6.0.1
+f90nml==1.4.4

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,2 +1,4 @@
 pytest==8.0.1
 jsonschema==4.21.1
+requests==2.31.0
+PyYAML==6.0.1

--- a/test/test_access_om2_config.py
+++ b/test/test_access_om2_config.py
@@ -35,7 +35,11 @@ class AccessOM2Branch:
             if res in self.branch_name:
                 self.resolution = res
                 return
-        # TODO Should unknown resolutions fail the pytests or be ignored?
+
+        pytest.fail(
+            f"Branch name {self.branch_name} has an unknown resolution. " +
+            f"Current supported resolutions: {', '.join(resolutions)}"
+        )
 
 
 @pytest.fixture(scope="class")
@@ -88,7 +92,6 @@ class TestAccessOM2:
         accessom2_nml = f90nml.read(accessom2_nml_path)
         restart_period = accessom2_nml['date_manager_nml']['restart_period']
 
-        # TODO: Here it's fixed, should it be a set of accepted values?
         if branch.resolution == '1deg':
             expected_period = [5, 0, 0]
         elif branch.resolution == '025deg':
@@ -102,7 +105,10 @@ class TestAccessOM2:
             else:
                 expected_period = [0, 3, 0]
         else:
-            return
+            pytest.fail(
+                f"The expected restart period is not defined for given "
+                f"resolution: {branch.resolution}"
+            )
         assert restart_period == expected_period
 
     def test_metadata_keywords(self, metadata):

--- a/test/test_access_om2_config.py
+++ b/test/test_access_om2_config.py
@@ -1,4 +1,3 @@
-from datetime import timedelta
 import re
 
 import pytest
@@ -60,14 +59,14 @@ class TestAccessOM2:
                     )
 
     def test_metadata_realm(self, metadata, branch):
-        expected_realms = ['ocean', 'seaIce']
+        expected_realms = {'ocean', 'seaIce'}
         expected_config = 'realm:\n - ocean\n - seaIce'
         if branch.is_bgc:
-            expected_realms.append('ocnBgchem')
+            expected_realms.add('ocnBgchem')
             expected_config += '\n - ocnBgchem'
 
         assert ('realm' in metadata
-                and metadata['realm'] == expected_realms), (
+                and set(metadata['realm']) == expected_realms), (
                     'Expected metadata realm set to:\n' + expected_config
                     )
 
@@ -78,7 +77,7 @@ class TestAccessOM2:
         accessom2_nml = f90nml.read(accessom2_nml_path)
         restart_period = accessom2_nml['date_manager_nml']['restart_period']
 
-        # TODO: Use set of expected periods?
+        # TODO: Here it's fixed, should it be a set of accepted values?
         if branch.resolution == '1deg':
             expected_period = [5, 0, 0]
         elif branch.resolution == '025deg':

--- a/test/test_access_om2_config.py
+++ b/test/test_access_om2_config.py
@@ -1,0 +1,116 @@
+from datetime import timedelta
+import re
+
+import pytest
+import f90nml
+
+from util import get_git_branch_name
+
+# Mutually exclusive topic keywords
+TOPIC_KEYWORDS = {
+    'spatial extent': {'global', 'regional'},
+    'forcing product':	{'JRA55', 'ERA5'},
+    'forcing mode': {'repeat-year', 'ryf', 'repeat-decade', 'rdf',
+                        'interannual', 'iaf'},
+    'model': {'access-om2', 'access-om2-025', 'access-om2-01'}
+}
+
+
+class AccessOM2Branch:
+    """Use the naming patterns of the branch name to infer informatiom of
+    the ACCESS-OM2 config"""
+
+    def __init__(self, branch_name):
+        self.branch_name = branch_name
+        self.set_resolution()
+
+        self.is_high_resolution = self.resolution in ['025deg', '01deg']
+        self.is_bgc = 'bgc' in branch_name
+
+    def set_resolution(self):
+        # Resolutions are ordered, so the start of the list are matched first
+        resolutions = ['025deg', '01deg', '1deg']
+        self.resolution = None
+        for res in resolutions:
+            if res in self.branch_name:
+                self.resolution = res
+                return
+        # TODO Should unknown resolutions fail the pytests or be ignored?
+
+
+@pytest.fixture(scope="class")
+def branch(control_path):
+    branch_name = get_git_branch_name(control_path)
+    assert branch_name is not None, (
+        f"Failed getting git branch name of control path: {control_path}"
+    )
+    return AccessOM2Branch(branch_name)
+
+
+@pytest.mark.access_om2
+class TestAccessOM2:
+    """ACCESS-OM2 Specific configuration and metadata tests"""
+
+    def test_mppncombine_fast_collate_exe(self, config, branch):
+        if branch.is_high_resolution:
+            pattern = r'/g/data/vk83/apps/mppnccombine-fast/.*/bin/mppnccombine-fast'
+            if 'collate' in config:
+                assert re.match(pattern, config['collate']['exe']), (
+                    "Expect collate executable set to mppnccombine-fast"
+                    )
+
+    def test_metadata_realm(self, metadata, branch):
+        expected_realms = ['ocean', 'seaIce']
+        expected_config = 'realm:\n - ocean\n - seaIce'
+        if branch.is_bgc:
+            expected_realms.append('ocnBgchem')
+            expected_config += '\n - ocnBgchem'
+
+        assert ('realm' in metadata
+                and metadata['realm'] == expected_realms), (
+                    'Expected metadata realm set to:\n' + expected_config
+                    )
+
+    def test_restart_period(self, branch, control_path):
+        accessom2_nml_path = control_path / 'accessom2.nml'
+        assert accessom2_nml_path.exists()
+
+        accessom2_nml = f90nml.read(accessom2_nml_path)
+        restart_period = accessom2_nml['date_manager_nml']['restart_period']
+
+        # TODO: Use set of expected periods?
+        if branch.resolution == '1deg':
+            expected_period = [5, 0, 0]
+        elif branch.resolution == '025deg':
+            if branch.is_bgc:
+                expected_period = [1, 0, 0]
+            else:
+                expected_period = [2, 0, 0]
+        elif branch.resolution == '01deg':
+            if branch.is_bgc:
+                expected_period = [0, 1, 0]
+            else:
+                expected_period = [0, 3, 0]
+        else:
+            return
+        assert restart_period == expected_period
+
+    def test_metadata_keywords(self, metadata):
+
+        assert 'keywords' in metadata
+        metadata_keywords = set(metadata['keywords'])
+
+        expected_keywords = set()
+        for topic, keywords in TOPIC_KEYWORDS.items():
+            mutually_exclusive = metadata_keywords.intersection(keywords)
+            assert len(mutually_exclusive) <= 1, (
+                f"Topic {topic} has multiple mutually exlusive keywords: " +
+                str(mutually_exclusive)
+                )
+
+            expected_keywords = expected_keywords.union(keywords)
+
+        unrecognised_keywords = metadata_keywords.difference(expected_keywords)
+        assert len(unrecognised_keywords) == 0, (
+            f"Metadata has unrecognised keywords: {unrecognised_keywords}"
+            )

--- a/test/test_access_om2_config.py
+++ b/test/test_access_om2_config.py
@@ -2,6 +2,7 @@ import re
 
 import pytest
 import f90nml
+import warnings
 
 from util import get_git_branch_name
 
@@ -38,11 +39,21 @@ class AccessOM2Branch:
 
 
 @pytest.fixture(scope="class")
-def branch(control_path):
-    branch_name = get_git_branch_name(control_path)
-    assert branch_name is not None, (
-        f"Failed getting git branch name of control path: {control_path}"
-    )
+def branch(control_path, target_branch):
+    branch_name = target_branch
+    if branch_name is None:
+        # Default to current branch name
+        branch_name = get_git_branch_name(control_path)
+        assert branch_name is not None, (
+             f"Failed getting git branch name of control path: {control_path}"
+        )
+        warnings.warn(
+            "Target branch is not specifed, defaulting to current git branch: "
+            f"{branch_name}. As some ACCESS-OM2 tests infer information, "
+            "such as resolution, from the target branch name, some tests may "
+            "not be run. To set use --target-branch flag in pytest call"
+        )
+
     return AccessOM2Branch(branch_name)
 
 

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -1,0 +1,179 @@
+"""Tests for checking configs and valid metadata files"""
+
+import pytest
+from pathlib import Path
+import re
+import requests
+import json
+import jsonschema
+
+import yaml
+
+@pytest.fixture(scope="class")
+def config(control_path: Path):
+    config_path = control_path / 'config.yaml'
+    with open(config_path) as f:
+        config_content = yaml.safe_load(f)
+    return config_content
+
+@pytest.fixture(scope="class")
+def exe_manifest_fullpaths(control_path: Path):
+    manifest_path = control_path / 'manifests' / 'exe.yaml'
+    with open(manifest_path) as f:
+        _, data = yaml.safe_load_all(f)
+    exe_fullpaths = {item['fullpath'] for item in data.values()}
+    return exe_fullpaths
+
+def insist_array(str_or_array):
+    if type(str_or_array) == str:
+        str_or_array = [ str_or_array, ]
+    return str_or_array
+
+@pytest.mark.config
+class TestConfig:
+    """Test contents of config.yaml files"""
+
+    @pytest.mark.parametrize(
+        "field", ["project", "shortpath"]
+    )
+    def test_field_is_not_defined(self, config, field):
+        assert field not in config, (
+            f"{field} should not be defined: '{field}: {config[field]}'"
+        )
+
+    def test_absolute_input_paths(self, config):
+        for path in insist_array(config.get('input', [])):
+            assert Path(path).is_absolute(), (
+                f"Input path should be absolute: {path}"
+            )
+    
+    def test_absolute_submodel_input_paths(self, config):
+        for model in config.get('submodels',[]):
+            for path in insist_array(model.get('input', [])):
+                assert Path(path).is_absolute(), (
+                    f"Input path for {model['name']} submodel should be " +
+                    f" absolute: {path}"
+                )
+    
+    def test_no_storage_qsub_flags(self, config):
+        qsub_flags = config.get('qsub_flags', '')
+        assert 'storage' not in qsub_flags, (
+            "Storage flags defined in qsub_flags will be silently ignored"
+        )
+    
+    def test_runlog_is_on(self, config):
+        runlog_config = config.get('runlog', {})
+        if isinstance(runlog_config, bool):
+            runlog_enabled = runlog_config
+        else:
+            runlog_enabled = runlog_config.get('enable', True)
+        assert runlog_enabled
+
+    def test_absolute_exe_path(self, config):
+        assert not 'exe' in config or Path(config['exe']).is_absolute(), (
+            f"Executable for model should be an absolute path: {config['exe']}"
+        )
+
+    def test_absolute_submodel_exe_path(self, config):
+        for model in config.get('submodels',[]):
+            if 'exe' not in model:
+                # Allow models such as couplers that have no executable
+                # TODO: Should a similar check be for the top level model?
+                if 'ncpus' in model and model['ncpus'] != 0:
+                    pytest.fail(f"No executable for submodel {model['name']}")
+                continue
+    
+            assert Path(model['exe']).is_absolute(), (
+                f"Executable for {model['name']} submodel should be " +
+                f"an absolute path: {config['exe']}"
+            )
+
+    def test_exe_paths_in_manifest(self, config, exe_manifest_fullpaths):
+        if 'exe' in config:
+            assert config['exe'] in exe_manifest_fullpaths, (
+                f"Model executable path should be in Manifest file " +
+                f"(e.g. manifests/exe.yaml): {config['exe']}"
+            )
+    
+    def test_sub_model_exe_paths_in_manifest(self,config,
+                                             exe_manifest_fullpaths):
+        for model in config.get('submodels',[]):
+            if 'exe' in model:
+                assert model['exe'] in exe_manifest_fullpaths, (
+                    f"Submodel {model['name']} executable path should be in " +
+                    f"Manifest file (e.g. manifests/exe.yaml): {config['exe']}"
+                )
+    
+    @pytest.mark.highres
+    def test_mppncombine_fast_collate_exe(self, config):
+        #TODO: how to check for mppncombine-fast?
+        if 'collate' in config:
+            assert config['collate']['exe'] == '/g/data/ik11/inputs/access-om2/bin/mppnccombine-fast'
+
+    def test_restart_freq_is_date_based(self, config):
+        assert "restart_freq" in config, "Restart frequency should be defined"
+        frequency = config["restart_freq"]
+        # String of an integer followed by a YS/MS/W/D/H/T/S unit,
+        # e.g. 1YS for 1 year-start
+        pattern = r'^\d+(YS|MS|W|D|H|T|S)$'
+        assert isinstance(frequency, str) and re.match(pattern, frequency), (
+           "Restart frequency should be date-based: " +
+           f"'restart_freq: {frequency}'" 
+        )
+
+    def test_sync_is_not_enabled(self, config):
+        if 'sync' in config and 'enable' in config['sync']:
+            assert not config['sync']['enable'], (
+                "Sync to remote archive should not be enabled"
+            )
+
+    def test_sync_path_is_not_set(self, config):
+        if 'sync' in config:
+            assert 'path' not in config['sync'], (
+                "Sync path to remote archive should not be set"
+            )
+
+
+def test_no_scripts_in_top_level_directory(control_path):
+    exts = {".py", ".sh"}
+    scripts = [p for p in control_path.iterdir() if p.suffix in exts]
+    assert scripts == [], (
+        "Scripts in top-level directory should be moved to a " + 
+        "'tools' sub-directory"
+    )
+
+
+# #TODO: Pointing to main, allows testing to point to recent schema versions, though makes this test code less robust. 
+# BASE_SCHEMA_URL = "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/output/experiment-metadata/"
+# DEFAULT_SCHEMA_VERSION = "1-0-0"
+
+
+# class TestMetadata:
+
+#     def setup_class(self, control_path):
+#         metadata_path = control_path / 'metadata.yaml'
+#         with open(metadata_path) as f:
+#             self.metadata = yaml.safe_load(f)
+
+#     def test_valid_metadata(self):
+#         schema_version = self.metadata.get("schema_version", DEFAULT_SCHEMA_VERSION)
+#         schema = get_schema_from_url()
+
+
+
+# def test_valid_metadata(control_path):
+#     metadata_path = control_path / 'metadata.yaml'
+#     with open(metadata_path) as f:
+#         metadata = yaml.safe_load(f)
+    
+#     schema = get_schema_from_url()
+
+#     # Validate checksums against schema
+#     jsonschema.validate(instance=metadata, schema=schema)
+
+# #TODO: Move to utils
+# def get_schema_from_url(url):
+#     """Retrieve schema from github"""
+#     response = requests.get(url)
+#     assert response.status_code == 200
+#     return response.json()

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -1,13 +1,28 @@
 """Tests for checking configs and valid metadata files"""
 
-import pytest
 from pathlib import Path
 import re
-import requests
-import json
-import jsonschema
 
+import pytest
+import requests
+import jsonschema
 import yaml
+
+# #TODO: Pointing to main, allows testing to point to recent schema versions,
+# though makes this test code less robust.
+# Could point to a commit - then if schema_version was a version not defined,
+# at that commit, use the default schema version.
+BASE_SCHEMA_URL = "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/output/experiment-metadata/"
+DEFAULT_SCHEMA_VERSION = "1-0-0"
+
+
+@pytest.fixture(scope="class")
+def metadata(control_path: Path):
+    metadata_path = control_path / 'metadata.yaml'
+    with open(metadata_path) as f:
+        content = yaml.safe_load(f)
+    return content
+
 
 @pytest.fixture(scope="class")
 def config(control_path: Path):
@@ -15,6 +30,7 @@ def config(control_path: Path):
     with open(config_path) as f:
         config_content = yaml.safe_load(f)
     return config_content
+
 
 @pytest.fixture(scope="class")
 def exe_manifest_fullpaths(control_path: Path):
@@ -24,10 +40,12 @@ def exe_manifest_fullpaths(control_path: Path):
     exe_fullpaths = {item['fullpath'] for item in data.values()}
     return exe_fullpaths
 
+
 def insist_array(str_or_array):
-    if type(str_or_array) == str:
-        str_or_array = [ str_or_array, ]
+    if isinstance(str_or_array, str):
+        str_or_array = [str_or_array,]
     return str_or_array
+
 
 @pytest.mark.config
 class TestConfig:
@@ -46,21 +64,21 @@ class TestConfig:
             assert Path(path).is_absolute(), (
                 f"Input path should be absolute: {path}"
             )
-    
+
     def test_absolute_submodel_input_paths(self, config):
-        for model in config.get('submodels',[]):
+        for model in config.get('submodels', []):
             for path in insist_array(model.get('input', [])):
                 assert Path(path).is_absolute(), (
                     f"Input path for {model['name']} submodel should be " +
                     f" absolute: {path}"
                 )
-    
+
     def test_no_storage_qsub_flags(self, config):
         qsub_flags = config.get('qsub_flags', '')
         assert 'storage' not in qsub_flags, (
             "Storage flags defined in qsub_flags will be silently ignored"
         )
-    
+
     def test_runlog_is_on(self, config):
         runlog_config = config.get('runlog', {})
         if isinstance(runlog_config, bool):
@@ -70,19 +88,19 @@ class TestConfig:
         assert runlog_enabled
 
     def test_absolute_exe_path(self, config):
-        assert not 'exe' in config or Path(config['exe']).is_absolute(), (
+        assert 'exe' not in config or Path(config['exe']).is_absolute(), (
             f"Executable for model should be an absolute path: {config['exe']}"
         )
 
     def test_absolute_submodel_exe_path(self, config):
-        for model in config.get('submodels',[]):
+        for model in config.get('submodels', []):
             if 'exe' not in model:
                 # Allow models such as couplers that have no executable
                 # TODO: Should a similar check be for the top level model?
                 if 'ncpus' in model and model['ncpus'] != 0:
                     pytest.fail(f"No executable for submodel {model['name']}")
                 continue
-    
+
             assert Path(model['exe']).is_absolute(), (
                 f"Executable for {model['name']} submodel should be " +
                 f"an absolute path: {config['exe']}"
@@ -94,21 +112,15 @@ class TestConfig:
                 f"Model executable path should be in Manifest file " +
                 f"(e.g. manifests/exe.yaml): {config['exe']}"
             )
-    
-    def test_sub_model_exe_paths_in_manifest(self,config,
+
+    def test_sub_model_exe_paths_in_manifest(self, config,
                                              exe_manifest_fullpaths):
-        for model in config.get('submodels',[]):
+        for model in config.get('submodels', []):
             if 'exe' in model:
                 assert model['exe'] in exe_manifest_fullpaths, (
                     f"Submodel {model['name']} executable path should be in " +
                     f"Manifest file (e.g. manifests/exe.yaml): {config['exe']}"
                 )
-    
-    @pytest.mark.highres
-    def test_mppncombine_fast_collate_exe(self, config):
-        #TODO: how to check for mppncombine-fast?
-        if 'collate' in config:
-            assert config['collate']['exe'] == '/g/data/ik11/inputs/access-om2/bin/mppnccombine-fast'
 
     def test_restart_freq_is_date_based(self, config):
         assert "restart_freq" in config, "Restart frequency should be defined"
@@ -118,7 +130,7 @@ class TestConfig:
         pattern = r'^\d+(YS|MS|W|D|H|T|S)$'
         assert isinstance(frequency, str) and re.match(pattern, frequency), (
            "Restart frequency should be date-based: " +
-           f"'restart_freq: {frequency}'" 
+           f"'restart_freq: {frequency}'"
         )
 
     def test_sync_is_not_enabled(self, config):
@@ -129,51 +141,74 @@ class TestConfig:
 
     def test_sync_path_is_not_set(self, config):
         if 'sync' in config:
-            assert 'path' not in config['sync'], (
+            assert not ('path' in config['sync']
+                        and config['sync']['path'] is not None), (
                 "Sync path to remote archive should not be set"
             )
 
 
+@pytest.mark.config
 def test_no_scripts_in_top_level_directory(control_path):
     exts = {".py", ".sh"}
     scripts = [p for p in control_path.iterdir() if p.suffix in exts]
     assert scripts == [], (
-        "Scripts in top-level directory should be moved to a " + 
+        "Scripts in top-level directory should be moved to a " +
         "'tools' sub-directory"
     )
 
 
-# #TODO: Pointing to main, allows testing to point to recent schema versions, though makes this test code less robust. 
-# BASE_SCHEMA_URL = "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/output/experiment-metadata/"
-# DEFAULT_SCHEMA_VERSION = "1-0-0"
+@pytest.mark.highres
+def test_mppncombine_fast_collate_exe(config):
+    pattern = r'/g/data/vk83/apps/mppnccombine-fast/.*/bin/mppnccombine-fast'
+    if 'collate' in config:
+        assert re.match(pattern, config['collate']['exe']), (
+            "Expect collate executable set to mppnccombine-fast"
+            )
 
 
-# class TestMetadata:
+@pytest.mark.metadata
+def test_validate_metadata(metadata):
+    # Schema URL
+    schema_version = metadata.get("schema_version", DEFAULT_SCHEMA_VERSION)
+    url = f"{BASE_SCHEMA_URL}/{schema_version}.json"
 
-#     def setup_class(self, control_path):
-#         metadata_path = control_path / 'metadata.yaml'
-#         with open(metadata_path) as f:
-#             self.metadata = yaml.safe_load(f)
+    # Get schema from Github
+    response = requests.get(url)
+    assert response.status_code == 200
+    schema = response.json()
 
-#     def test_valid_metadata(self):
-#         schema_version = self.metadata.get("schema_version", DEFAULT_SCHEMA_VERSION)
-#         schema = get_schema_from_url()
+    # TODO: In version (1-0-0), required fields are name, experiment_uuid,
+    # description and long_description. Removing the required fields
+    # from the schema validation for now
+    schema.pop('required')
+
+    # Experiment_uuid
+    jsonschema.validate(instance=metadata, schema=schema)
 
 
+@pytest.mark.metadata
+@pytest.mark.parametrize(
+    "field",
+    ["description", "notes", "keywords", "nominal resolution", "version",
+     "reference", "license", "url", "model", "realm"]
+)
+def test_metadata_contains_fields(field, metadata):
+    assert field in metadata, f"{field} field shoud be defined in metadata"
 
-# def test_valid_metadata(control_path):
-#     metadata_path = control_path / 'metadata.yaml'
-#     with open(metadata_path) as f:
-#         metadata = yaml.safe_load(f)
-    
-#     schema = get_schema_from_url()
 
-#     # Validate checksums against schema
-#     jsonschema.validate(instance=metadata, schema=schema)
+@pytest.mark.access_om2_bcm
+def test_metadata_realm(metadata):
+    assert ('realm' in metadata
+            and metadata['realm'] == ['ocean', 'seaIce', 'ocnBgchem']), (
+            'Expected access-om2-bgc metadata realm set to:\n' +
+            'realm:\n - ocean\n - seaIce\n - ocnBgchem'
+            )
 
-# #TODO: Move to utils
-# def get_schema_from_url(url):
-#     """Retrieve schema from github"""
-#     response = requests.get(url)
-#     assert response.status_code == 200
-#     return response.json()
+
+@pytest.mark.access_om2
+def test_metadata_access_om2_realm(metadata):
+    assert ('realm' in metadata
+            and metadata['realm'] == ['ocean', 'seaIce']), (
+            'Expected access-om2 metadata realm set to:\n' +
+            'realm:\n - ocean\n - seaIce\n'
+            )

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -49,7 +49,7 @@ def insist_array(str_or_array):
 
 @pytest.mark.config
 class TestConfig:
-    """Test contents of config.yaml files"""
+    """General configuration tests"""
 
     @pytest.mark.parametrize(
         "field", ["project", "shortpath"]
@@ -152,17 +152,14 @@ class TestConfig:
             "Executable reproducibility should be enforced, e.g set:\n" +
             "manifest:\n    reproduce:\n        exe: True"
             )
-        config.get('manifest', {}).get('reproduce', {})
 
-
-@pytest.mark.config
-def test_no_scripts_in_top_level_directory(control_path):
-    exts = {".py", ".sh"}
-    scripts = [p for p in control_path.iterdir() if p.suffix in exts]
-    assert scripts == [], (
-        "Scripts in top-level directory should be moved to a " +
-        "'tools' sub-directory"
-    )
+    def test_no_scripts_in_top_level_directory(self, control_path):
+        exts = {".py", ".sh"}
+        scripts = [p for p in control_path.iterdir() if p.suffix in exts]
+        assert scripts == [], (
+            "Scripts in top-level directory should be moved to a " +
+            "'tools' sub-directory"
+        )
 
 
 @pytest.mark.highres

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -196,7 +196,7 @@ def test_metadata_contains_fields(field, metadata):
     assert field in metadata, f"{field} field shoud be defined in metadata"
 
 
-@pytest.mark.access_om2_bcm
+@pytest.mark.access_om2_bgc
 def test_metadata_realm(metadata):
     assert ('realm' in metadata
             and metadata['realm'] == ['ocean', 'seaIce', 'ocnBgchem']), (

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -96,7 +96,6 @@ class TestConfig:
         for model in config.get('submodels', []):
             if 'exe' not in model:
                 # Allow models such as couplers that have no executable
-                # TODO: Should a similar check be for the top level model?
                 if 'ncpus' in model and model['ncpus'] != 0:
                     pytest.fail(f"No executable for submodel {model['name']}")
                 continue
@@ -182,8 +181,9 @@ def test_validate_metadata(metadata):
     assert response.status_code == 200
     schema = response.json()
 
-    # TODO: In version (1-0-0), required fields are name, experiment_uuid,
-    # description and long_description. Removing the required fields
+    # In schema version (1-0-0), required fields are name, experiment_uuid,
+    # description and long_description. As name & experiment_uuid are
+    # generated for running experiments, the required fields are removed
     # from the schema validation for now
     schema.pop('required')
 

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -146,6 +146,14 @@ class TestConfig:
                 "Sync path to remote archive should not be set"
             )
 
+    def test_manifest_reproduce_exe_is_on(self, config):
+        manifest_reproduce = config.get('manifest', {}).get('reproduce', {})
+        assert 'exe' in manifest_reproduce and manifest_reproduce['exe'], (
+            "Executable reproducibility should be enforced, e.g set:\n" +
+            "manifest:\n    reproduce:\n        exe: True"
+            )
+        config.get('manifest', {}).get('reproduce', {})
+
 
 @pytest.mark.config
 def test_no_scripts_in_top_level_directory(control_path):

--- a/test/util.py
+++ b/test/util.py
@@ -18,3 +18,16 @@ def wait_for_qsub(run_id):
 
         if 'Job has finished' in qsub_out:
             break
+
+
+def get_git_branch_name(path):
+    """Get the git branch name of the given git directory"""
+    try:
+        cmd = 'git rev-parse --abbrev-ref HEAD'
+        result = sp.check_output(cmd, shell=True,
+                                         cwd=path).strip()
+        # Decode byte string to string
+        branch_name = result.decode('utf-8')
+        return branch_name
+    except sp.CalledProcessError:
+        return None


### PR DESCRIPTION
Add CI checks for checking `config.yaml`, `metadata.yaml` files and simple configuration directory checks, as described in #25.  

Closes #25

TODO:
- [x] Add Metadata pytests
- [x] Add new CI job that runs the pytests on PRs merging into `release-*` and `dev-*`