### PR TITLE
Update scheduled release config tag check

### DIFF
--- a/config/released-configs.json
+++ b/config/released-configs.json
@@ -1,6 +1,6 @@
 {
     "$schema": "./released-configs.schema.json",
     "tags": [
-        "release-1deg_jra55_ryf-1.0.0"
+        "release-1deg_jra55_ryf-1.0"
     ]
 }


### PR DESCRIPTION
`released-configs.json` now uses correct, existing config tag (`release-1deg_jra55_ryf-1.0` instead of `release-1deg_jra55_ryf-1.0.0`.

Closes #21 