### PR TITLE
Give `permissions.checks:write` to Scheduled Checks

### DIFF
--- a/.github/workflows/schedule-1-ci.yml
+++ b/.github/workflows/schedule-1-ci.yml
@@ -32,5 +32,6 @@ jobs:
       config-tag: ${{ matrix.config-tag }}
     secrets: inherit
     permissions:
+      checks: write
       contents: write
       issues: write

--- a/.github/workflows/schedule-2-start.yml
+++ b/.github/workflows/schedule-2-start.yml
@@ -26,6 +26,8 @@ jobs:
     needs:
       - repro-ci
     runs-on: ubuntu-latest
+    permissions:
+      checks: write
     env:
       TESTING_LOCAL_LOCATION: /opt/testing
     outputs:


### PR DESCRIPTION
See failling run here: https://github.com/ACCESS-NRI/access-om2-configs/actions/runs/8415375297/job/23040581361#step:3:339

For Scheduled checks, we still required the `permissions.checks: write` even if we a not doing a pull request. 

This PR:
* Gives `permissions.checks:write` to both the overall `schedule-2-start.yml` reusable workflow and the job inside it (`check-checksum`)