### PR TITLE
Properly Compared Number of Failed Tests in JSON for Failure Notifier

### DIFF
--- a/.github/workflows/schedule-2-start.yml
+++ b/.github/workflows/schedule-2-start.yml
@@ -60,7 +60,7 @@ jobs:
         run: |
           echo "check-url=${{ fromJson(steps.tests.outputs.json).check_url }}" >> $GITHUB_OUTPUT
           echo "compared-checksum-version=${{ inputs.config-tag }}" >> $GITHUB_OUTPUT
-          if [ "${{ fromJson(steps.tests.outputs.json).stats.tests_fail }}" > 0 ]; then
+          if [ "${{ fromJson(steps.tests.outputs.json).stats.tests_fail }}" -gt "0" ]; then
             echo "result=fail" >> $GITHUB_OUTPUT
           else
             echo "result=pass" >> $GITHUB_OUTPUT


### PR DESCRIPTION
See failed run: https://github.com/ACCESS-NRI/access-om2-configs/actions/runs/8428361335/job/23080831075#step:4:4

I incorrectly compare a string with a number (`[ "0" > 0 ]`), which will always be true and set off the failure notifier. 

This PR updates that check to use a POSIX-compilant method for comparing numbers.