### PR TITLE
generate-initial-checksums.yml: Added user-specifiable tag version

### DIFF
--- a/.github/workflows/generate-initial-checksums.yml
+++ b/.github/workflows/generate-initial-checksums.yml
@@ -9,12 +9,17 @@ on:
       commit-checksums:
         type: boolean
         required: true
-        description: Whether to commit the checksums to the target branch once generated.
+        description: Whether to commit the checksums to the target branch once generated. They will still be stored as a workflow artifact.
       committed-checksum-location:
         type: string
         required: false
         default: ./testing/checksum
         description: "If `commit-checksums`: Where in the repository the generated checksums should be committed to."
+      committed-checksum-tag-version:
+        type: string
+        required: true
+        default: '1.0'
+        description: "If `commit-checksums`: The initial version for the git tag associated with the committed checksums."
 jobs:
   generate-checksums:
     name: Generate Checksums
@@ -24,7 +29,7 @@ jobs:
       config-branch-name: ${{ inputs.config-branch-name }}
       commit-checksums: ${{ inputs.commit-checksums }}
       committed-checksum-location: ${{ inputs.committed-checksum-location }}
-      committed-checksum-tag: "${{ inputs.config-branch-name }}-1.0"
+      committed-checksum-tag: "${{ inputs.config-branch-name }}-${{ inputs.committed-checksum-tag-version }}"
       environment-name: "Gadi Initial Checksum"
     permissions:
       contents: write


### PR DESCRIPTION
This allows users to generate the initial checksums to have a version that is not `1.0` for all initial checksums. 