### PR TITLE
Add extra QA CI checks

### DIFF
--- a/test/test_access_om2_config.py
+++ b/test/test_access_om2_config.py
@@ -15,6 +15,14 @@ TOPIC_KEYWORDS = {
     'model': {'access-om2', 'access-om2-025', 'access-om2-01'}
 }
 
+# Nominal resolutions are sourced from CMIP6 controlled vocabulary
+# https://github.com/WCRP-CMIP/CMIP6_CVs/blob/main/CMIP6_nominal_resolution.json
+NOMINAL_RESOLUTION = {
+    '025deg': {'25 km'},
+    '01deg': {'10 km'},
+    '1deg': {'100 km'}
+}
+
 
 class AccessOM2Branch:
     """Use the naming patterns of the branch name to infer informatiom of
@@ -73,6 +81,16 @@ class TestAccessOM2:
                     "Expect collate executable set to mppnccombine-fast"
                     )
 
+    def test_sync_userscript_ice_concatenation(self, config):
+        # This script runs in the sync pbs job before syncing output to a
+        # remote location
+        script = '/g/data/vk83/apps/om2-scripts/concatenate_ice/concat_ice_daily.sh'
+        assert ('userscripts' in config and 'sync' in config['userscripts']
+                and config['userscripts']['sync'] == script), (
+                    "Expect sync userscript set to ice-concatenation script." +
+                    f"\nuserscript:\n  sync: {script}"
+                )
+
     def test_metadata_realm(self, metadata, branch):
         expected_realms = {'ocean', 'seaIce'}
         expected_config = 'realm:\n - ocean\n - seaIce'
@@ -130,3 +148,16 @@ class TestAccessOM2:
         assert len(unrecognised_keywords) == 0, (
             f"Metadata has unrecognised keywords: {unrecognised_keywords}"
             )
+
+    def test_metadata_nominal_resolution(self, metadata, branch):
+        assert branch.resolution in NOMINAL_RESOLUTION, (
+            f"The expected nominal_resolution is not defined for given " +
+            f"resolution: {branch.resolution}"
+        )
+
+        expected = NOMINAL_RESOLUTION[branch.resolution]
+        assert ('nominal_resolution' in metadata
+                and set(metadata['nominal_resolution']) == expected), (
+                    f"Expected nominal_resolution field set to: {expected} " +
+                    f"\nnominal_resolutionzz:\n - {"\n - ".join(expected)}"
+                    )

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -135,6 +135,21 @@ class TestConfig:
             "manifest:\n    reproduce:\n        exe: True"
             )
 
+    def test_metadata_is_enabled(self, config):
+        if 'metadata' in config and 'enable' in config['metadata']:
+            assert config['metadata']['enable'], (
+                "Metadata should be enabled, otherwise new UUIDs will not " +
+                "be generated and branching in Payu would not work - as " +
+                "branch and UUIDs are not used in the name used for archival."
+            )
+
+    def test_experiment_name_is_not_defined(self, config):
+        assert 'experiment' not in config, (
+            f"experiment: {config['experiment']} should not set, " +
+            "as this over-rides the experiment name used for archival. " +
+            "If set, branching in payu would not work."
+        )
+
     def test_no_scripts_in_top_level_directory(self, control_path):
         exts = {".py", ".sh"}
         scripts = [p for p in control_path.iterdir() if p.suffix in exts]
@@ -174,8 +189,13 @@ class TestConfig:
 
     @pytest.mark.parametrize(
         "field",
-        ["description", "notes", "keywords", "nominal resolution", "version",
-        "reference", "license", "url", "model", "realm"]
+        ["description", "notes", "keywords", "nominal_resolution", "version",
+        "reference", "url", "model", "realm"]
     )
     def test_metadata_contains_fields(self, field, metadata):
         assert field in metadata, f"{field} field shoud be defined in metadata"
+
+    def test_metadata_license(self, metadata):
+        assert 'license' in metadata and metadata['license'] == 'CC-BY-4.0', (
+            "The license should be set to CC-BY-4.0"
+            )


### PR DESCRIPTION
- Test metadata is enabled
- Ensure experiment in config is not defined
- license in metadata set to CC-BY-4.0
- access-om2 sync userscript set to ice concat script
- access-om2 check nominal resolution in metadata

Closes #45

I've assumed the license is a general config check rather than just access-om2 specific? 