### PR TITLE
Update QA pytests

### DIFF
--- a/test/test_access_om2_config.py
+++ b/test/test_access_om2_config.py
@@ -18,9 +18,9 @@ TOPIC_KEYWORDS = {
 # Nominal resolutions are sourced from CMIP6 controlled vocabulary
 # https://github.com/WCRP-CMIP/CMIP6_CVs/blob/main/CMIP6_nominal_resolution.json
 NOMINAL_RESOLUTION = {
-    '025deg': {'25 km'},
-    '01deg': {'10 km'},
-    '1deg': {'100 km'}
+    '025deg': '25 km',
+    '01deg': '10 km',
+    '1deg': '100 km'
 }
 
 
@@ -159,6 +159,5 @@ class TestAccessOM2:
         expected = NOMINAL_RESOLUTION[branch.resolution]
         assert ('nominal_resolution' in metadata
                 and metadata['nominal_resolution'] == expected), (
-                    f"Expected nominal_resolution field set to: {expected} " +
-                    f"\nnominal_resolution: {metadata['nominal_resolution']}"
+                    f"Expected nominal_resolution field set to: {expected}"
                     )

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -9,12 +9,13 @@ import requests
 import jsonschema
 import yaml
 
-#TODO: Change to latest schema - 1-0-3? Otherwise use sets for nominal_resolution
+# Experiment Metadata Schema
 BASE_SCHEMA_URL = "https://raw.githubusercontent.com/ACCESS-NRI/schema"
 BASE_SCHEMA_PATH = "au.org.access-nri/model/output/experiment-metadata"
 SCHEMA_VERSION = "1-0-3"
 SCHEMA_COMMIT = "4b7207e47afe402a732c58741ff66acc5f93b8cf"
 
+# CC BY 4.0 License
 LICENSE = "CC-BY-4.0"
 LICENSE_URL = "https://creativecommons.org/licenses/by/4.0/legalcode.txt"
 
@@ -187,6 +188,12 @@ class TestConfig:
     )
     def test_metadata_contains_fields(self, field, metadata):
         assert field in metadata, f"{field} field shoud be defined in metadata"
+
+    def test_metadata_does_contain_UUID(self, metadata):
+        assert 'experiment_uuid' not in metadata, (
+            "`experiment_uuid` should not be defined in metadata, " +
+            "as this is an configuration rather than an experiment. "
+        )
 
     def test_metadata_license(self, metadata):
         assert 'license' in metadata and metadata['license'] == LICENSE, (

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -12,11 +12,11 @@ import yaml
 #TODO: Change to latest schema - 1-0-3? Otherwise use sets for nominal_resolution
 BASE_SCHEMA_URL = "https://raw.githubusercontent.com/ACCESS-NRI/schema"
 BASE_SCHEMA_PATH = "au.org.access-nri/model/output/experiment-metadata"
-SCHEMA_VERSION = "1-0-2"
-SCHEMA_COMMIT = "e9055da95093ec2faa555c090fc5af17923d1566"
+SCHEMA_VERSION = "1-0-3"
+SCHEMA_COMMIT = "4b7207e47afe402a732c58741ff66acc5f93b8cf"
 
 LICENSE = "CC-BY-4.0"
-LICENSE_URL = "https://creativecommons.org/licenses/by-sa/4.0/legalcode.txt"
+LICENSE_URL = "https://creativecommons.org/licenses/by/4.0/legalcode.txt"
 
 
 @pytest.fixture(scope="class")


### PR DESCRIPTION
- Add test for license file and contents, closes #56
- Change access-om2 nominal resolutions to strings, closes #57 
- Change metadata schema url to point to one schema commit -  as schemas should be backwards compatible

