### PR TITLE
Added `pr-3-bump-tag.yml` null check

### DIFF
--- a/.github/workflows/pr-3-bump-tag.yml
+++ b/.github/workflows/pr-3-bump-tag.yml
@@ -24,9 +24,13 @@ jobs:
         # Check if the tag already exists, if it does, we don't want to move it.
         id: tag
         run: |
-          VERSION_TAG=${{ github.ref_name }}-$(yq '.version' metadata.yaml)
+          VERSION=$(yq '.version' metadata.yaml)
+          VERSION_TAG=${{ github.ref_name }}-$VERSION
           VERSION_TAG_ON_GIT=$(git tag -l $VERSION_TAG)
-          if [ -n "$VERSION_TAG_ON_GIT" ]; then
+          if [[ "$VERSION" == "null" ]]; then
+            echo "::warning::Version is null. Skipping."
+            exit 1
+          elif [ -n "$VERSION_TAG_ON_GIT" ]; then
             echo "::warning::Tag $VERSION_TAG already exists. Skipping."
             echo "exists=true" >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
Relates to the erroneous running of `pr-3-bump-tag.yml` on initial merge of a `dev-*` branch into `release-*`, see https://github.com/ACCESS-NRI/access-om2-configs/actions/runs/8638862592

In this PR:
* `pr-3-bump-tag.yml`: Added null check