### PR TITLE
Add additional QA checks

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -3,6 +3,7 @@ import pytest
 from pathlib import Path
 
 import yaml
+from ruamel.yaml import YAML
 
 
 @pytest.fixture(scope="session")
@@ -43,8 +44,9 @@ def checksum_path(request, control_path):
 def metadata(control_path: Path):
     """Read the metadata file in the control directory"""
     metadata_path = control_path / 'metadata.yaml'
-    with open(metadata_path) as f:
-        content = yaml.safe_load(f)
+    # Use ruamel.yaml as that is what is used to read metadata files in Payu
+    # It also errors out if there are duplicate keys in metadata
+    content = YAML().load(metadata_path)
     return content
 
 

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -3,3 +3,4 @@ jsonschema==4.21.1
 requests
 PyYAML
 f90nml>=0.16
+ruamel.yaml>=0.18.5

--- a/test/test_access_om2_config.py
+++ b/test/test_access_om2_config.py
@@ -12,7 +12,8 @@ TOPIC_KEYWORDS = {
     'forcing product':	{'JRA55', 'ERA5'},
     'forcing mode': {'repeat-year', 'ryf', 'repeat-decade', 'rdf',
                         'interannual', 'iaf'},
-    'model': {'access-om2', 'access-om2-025', 'access-om2-01'}
+    'model': {'access-om2', 'access-om2-025', 'access-om2-01'},
+    'model variant': {'bgc'}
 }
 
 # Nominal resolutions are sourced from CMIP6 controlled vocabulary
@@ -80,6 +81,10 @@ class TestAccessOM2:
                 assert re.match(pattern, config['collate']['exe']), (
                     "Expect collate executable set to mppnccombine-fast"
                     )
+
+                assert config['collate']['mpi'], (
+                    "Expect `mpi: true` when using mppnccombine-fast"
+                )
 
     def test_sync_userscript_ice_concatenation(self, config):
         # This script runs in the sync pbs job before syncing output to a


### PR DESCRIPTION
- Read metadata.yaml using ruamel.yaml (as what is used in payu) which errors out on duplicated fields. Closes #80
- Add bgc keyword to list of allowable keywords. Closes #62
- Check for `mpi: true` when using `mppnccombine-fast`. Closes #70