### PR TITLE
Specifiable `pytest` Test Versions for `Scheduled` Testing

### DIFF
--- a/.github/workflows/schedule-1-ci.yml
+++ b/.github/workflows/schedule-1-ci.yml
@@ -46,7 +46,7 @@ jobs:
     uses: ./.github/workflows/schedule-2-start.yml
     with:
       config-tag: ${{ matrix.config-tag }}
-      tests-version: ${{ needs.setup.outputs.tests-version }}
+      pytest-tests-version: ${{ needs.setup.outputs.tests-version }}
     secrets: inherit
     permissions:
       checks: write

--- a/.github/workflows/schedule-1-ci.yml
+++ b/.github/workflows/schedule-1-ci.yml
@@ -1,6 +1,12 @@
 name: Scheduled Checks
 on:
   workflow_dispatch:
+    inputs:
+      pytest-tests-version:
+        type: string
+        required: true
+        default: main
+        description: commit, branch or tag containing a particular version of the pytest tests
   schedule:
     - cron: '0 0 1 * *'  # once a month
 jobs:
@@ -9,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       tags: ${{ steps.get-released-config.outputs.tags }}
+      tests-version: ${{ steps.get-tests-version.outputs.version }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -17,6 +24,15 @@ jobs:
       - name: Get all released configs
         id: get-released-config
         run: echo "tags=$(jq --compact-output --raw-output '.tags' config/released-configs.json)" >> $GITHUB_OUTPUT
+
+      - name: Get pytests tests version
+        id: get-tests-version
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "version=${{ inputs.pytest-tests-version }}" >> $GITHUB_OUTPUT
+          else
+            echo "version=$(jq --compact-output --raw-output '."tests-version"' config/released-configs.json)" >> $GITHUB_OUTPUT
+          fi
 
   repro-ci:
     # We use this reusable workflow with a matrix strategy rather than calling repro-ci.yml, as
@@ -30,6 +46,7 @@ jobs:
     uses: ./.github/workflows/schedule-2-start.yml
     with:
       config-tag: ${{ matrix.config-tag }}
+      tests-version: ${{ needs.setup.outputs.tests-version }}
     secrets: inherit
     permissions:
       checks: write

--- a/.github/workflows/schedule-2-start.yml
+++ b/.github/workflows/schedule-2-start.yml
@@ -6,6 +6,10 @@ on:
         type: string
         required: true
         description: Tag associated with a config branch that is used in the reproducibility run
+      tests-version:
+        type: string
+        required: true
+        description: commit, branch or tag containing a particular version of the pytest tests
 jobs:
   repro-ci:
     # Run the given config on the deployment Github Environment (`environment-name`) and upload
@@ -16,6 +20,7 @@ jobs:
       environment-name: Gadi
       config-tag: ${{ inputs.config-tag }}
       test-markers: checksum
+      test-version: ${{ inputs.tests-version }}
     secrets: inherit
     permissions:
       contents: write
@@ -61,8 +66,10 @@ jobs:
           echo "check-url=${{ fromJson(steps.tests.outputs.json).check_url }}" >> $GITHUB_OUTPUT
           echo "compared-checksum-version=${{ inputs.config-tag }}" >> $GITHUB_OUTPUT
           if [ "${{ fromJson(steps.tests.outputs.json).stats.tests_fail }}" -gt "0" ]; then
+            echo "::notice::Ran tests on ${{ inputs.config-tag }} using pytest tests at version ${{ inputs.tests-version }}, and they succeeded."
             echo "result=fail" >> $GITHUB_OUTPUT
           else
+            echo "::warning::Ran tests on ${{ inputs.config-tag }} using pytest tests at version ${{ inputs.tests-version }}, but they failed."
             echo "result=pass" >> $GITHUB_OUTPUT
           fi
 
@@ -88,18 +95,19 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           BODY: |
-            There was a failure of a monthly reproducibility check on ${{ github.repository }}.
+            There was a failure of a monthly reproducibility check on `${{ github.repository }}`.
             Logs, checksums and other artifacts can be found at the Failed Run Log link below.
 
-            Model: ${{ env.MODEL }}, found here: ${{ env.MODEL_URL }}
-            Config Repo: ${{ env.CONFIG }}, found here: ${{ env.CONFIG_URL }}
-            Config Tag Tested for Reproducibility: ${{ needs.check-checksum.outputs.compared-checksum-version }}, found here: ${{ env.TAG_URL }}
+            Model: `${{ env.MODEL }}`, found here: ${{ env.MODEL_URL }}
+            Config Repo: `${{ env.CONFIG }}`, found here: ${{ env.CONFIG_URL }}
+            Config Tag Tested for Reproducibility: `${{ needs.check-checksum.outputs.compared-checksum-version }}`, found here: ${{ env.TAG_URL }}
+            Tests Version: `${{ inputs.tests-version }}`
             Failed Run Log: ${{ env.RUN_URL }}
-            Experiment Location (Gadi): ${{ needs.repro-ci.outputs.experiment-location }}
+            Experiment Location (Gadi): `${{ needs.repro-ci.outputs.experiment-location }}`
 
             Tagging @ACCESS-NRI/model-release
         run: |
           gh issue create \
             --title "Scheduled Repro Check Failed for Config ${{ needs.check-checksum.outputs.compared-checksum-version }}" \
             --label "type:repro-fail,priority:blocker" \
-            --body "${{ env.BODY }}"
+            --body '${{ env.BODY }}'

--- a/.github/workflows/schedule-2-start.yml
+++ b/.github/workflows/schedule-2-start.yml
@@ -6,7 +6,7 @@ on:
         type: string
         required: true
         description: Tag associated with a config branch that is used in the reproducibility run
-      tests-version:
+      pytest-tests-version:
         type: string
         required: true
         description: commit, branch or tag containing a particular version of the pytest tests
@@ -20,7 +20,7 @@ jobs:
       environment-name: Gadi
       config-tag: ${{ inputs.config-tag }}
       test-markers: checksum
-      test-version: ${{ inputs.tests-version }}
+      pytest-version: ${{ inputs.pytest-tests-version }}
     secrets: inherit
     permissions:
       contents: write
@@ -66,10 +66,10 @@ jobs:
           echo "check-url=${{ fromJson(steps.tests.outputs.json).check_url }}" >> $GITHUB_OUTPUT
           echo "compared-checksum-version=${{ inputs.config-tag }}" >> $GITHUB_OUTPUT
           if [ "${{ fromJson(steps.tests.outputs.json).stats.tests_fail }}" -gt "0" ]; then
-            echo "::notice::Ran tests on ${{ inputs.config-tag }} using pytest tests at version ${{ inputs.tests-version }}, and they succeeded."
+            echo "::notice::Ran tests on ${{ inputs.config-tag }} using pytest tests at version ${{ inputs.pytest-tests-version }}, and they succeeded."
             echo "result=fail" >> $GITHUB_OUTPUT
           else
-            echo "::warning::Ran tests on ${{ inputs.config-tag }} using pytest tests at version ${{ inputs.tests-version }}, but they failed."
+            echo "::warning::Ran tests on ${{ inputs.config-tag }} using pytest tests at version ${{ inputs.pytest-tests-version }}, but they failed."
             echo "result=pass" >> $GITHUB_OUTPUT
           fi
 
@@ -101,7 +101,7 @@ jobs:
             Model: `${{ env.MODEL }}`, found here: ${{ env.MODEL_URL }}
             Config Repo: `${{ env.CONFIG }}`, found here: ${{ env.CONFIG_URL }}
             Config Tag Tested for Reproducibility: `${{ needs.check-checksum.outputs.compared-checksum-version }}`, found here: ${{ env.TAG_URL }}
-            Tests Version: `${{ inputs.tests-version }}`
+            Tests Version: `${{ inputs.pytest-tests-version }}`
             Failed Run Log: ${{ env.RUN_URL }}
             Experiment Location (Gadi): `${{ needs.repro-ci.outputs.experiment-location }}`
 

--- a/config/released-configs.json
+++ b/config/released-configs.json
@@ -3,5 +3,6 @@
     "tags": [
         "release-1deg_jra55_ryf-2.0",
         "release-1deg_jra55_iaf_bgc-2.0"
-    ]
+    ],
+    "tests-version": "0156301"
 }

--- a/config/released-configs.schema.json
+++ b/config/released-configs.schema.json
@@ -12,8 +12,11 @@
             "items": {
                 "type": "string"
             }
+        },
+        "tests-version": {
+            "type": "string"
         }
     },
-    "required": ["tags"],
+    "required": ["tags", "tests-version"],
     "additionalProperties": false
 }


### PR DESCRIPTION
In this PR:
* `config/released-configs`: Added a new field for specifying the `pytest` tests version via a committish object
* `scheduled-*.yml`: Updated the scheduled workflow to use the specifiable `pytest` tests

Closes #61