### PR TITLE
Update exes to latest release: `025deg_jra55_ryf_bgc`

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -27,7 +27,7 @@ input:
 submodels:
     - name: atmosphere
       model: yatm
-      exe: /g/data/vk83/apps/spack/0.20/release/linux-rocky8-x86_64/intel-19.0.5.281/libaccessom2-git.2023.10.26=2023.10.26-ltfg7jcn6t4cefotvj3kjnyu5nru26xo/bin/yatm.exe
+      exe: /g/data/vk83/apps/spack/0.21/release/linux-rocky8-x86_64/intel-2021.10.0/libaccessom2-git.2023.10.26_2023.10.26-uzxs6bzbk5j5a3uz5uyallnb65iihllp/bin/yatm.exe
       input:
             - /g/data/vk83/experiments/inputs/access-om2/remapping_weights/JRA55/global.025deg/2020.05.30/rmp_jrar_to_cict_CONSERV.nc
             - /g/data/vk83/experiments/inputs/JRA-55/RYF/v1-4/data
@@ -35,7 +35,7 @@ submodels:
 
     - name: ocean
       model: mom
-      exe: /g/data/vk83/apps/spack/0.20/release/linux-rocky8-x86_64/intel-19.0.5.281/mom5-git.2023.11.09=2023.11.09-64l5azdtcoxhrgb5ynn2vued5lmjvn33/bin/fms_ACCESS-OM-BGC.x
+      exe: /g/data/vk83/apps/spack/0.21/release/linux-rocky8-x86_64/intel-2021.10.0/mom5-git.2024.06.27_2024.06.27-omyzessq2c636dguuzxac6i2onh3rsmf/bin/fms_ACCESS-OM-BGC.x
       input:
         - /g/data/vk83/experiments/inputs/access-om2/ocean/grids/mosaic/global.025deg/2020.05.30/grid_spec.nc
         - /g/data/vk83/experiments/inputs/access-om2/ocean/grids/mosaic/global.025deg/2020.05.30/ocean_hgrid.nc
@@ -60,7 +60,7 @@ submodels:
 
     - name: ice
       model: cice5
-      exe: /g/data/vk83/apps/spack/0.20/release/linux-rocky8-x86_64/intel-19.0.5.281/cice5-git.2023.10.19=2023.10.19-v3zncpqjj2gyseudbwiudolcjq3k3leo/bin/cice_auscom_1440x1080_48x40_480p.exe
+      exe: /g/data/vk83/apps/spack/0.21/release/linux-rocky8-x86_64/intel-2021.10.0/cice5-git.2023.10.19_2023.10.19-5fsgo7ngu72sepcoz4vho5737eiibmkf/bin/cice_auscom_1440x1080_48x40_480p.exe
       input:
         - /g/data/vk83/experiments/inputs/access-om2/ice/grids/global.025deg/2024.04.17/grid.nc
         - /g/data/vk83/experiments/inputs/access-om2/ice/grids/global.025deg/2024.04.17/kmt.nc

--- a/manifests/exe.yaml
+++ b/manifests/exe.yaml
@@ -2,17 +2,17 @@ format: yamanifest
 version: 1.0
 ---
 work/atmosphere/yatm.exe:
-  fullpath: /g/data/vk83/apps/spack/0.20/release/linux-rocky8-x86_64/intel-19.0.5.281/libaccessom2-git.2023.10.26=2023.10.26-ltfg7jcn6t4cefotvj3kjnyu5nru26xo/bin/yatm.exe
+  fullpath: /g/data/vk83/apps/spack/0.21/release/linux-rocky8-x86_64/intel-2021.10.0/libaccessom2-git.2023.10.26_2023.10.26-uzxs6bzbk5j5a3uz5uyallnb65iihllp/bin/yatm.exe
   hashes:
-    binhash: 4e8b4ef76e971c4af3b26cfac632e160
-    md5: 5baa1d417fe6708fc30cbeaa57d82f96
+    binhash: fc2345a914935d87651afbd31fa60051
+    md5: 4aa238b39c2eb807c9f32ea50d80968f
 work/ice/cice_auscom_1440x1080_48x40_480p.exe:
-  fullpath: /g/data/vk83/apps/spack/0.20/release/linux-rocky8-x86_64/intel-19.0.5.281/cice5-git.2023.10.19=2023.10.19-v3zncpqjj2gyseudbwiudolcjq3k3leo/bin/cice_auscom_1440x1080_48x40_480p.exe
+  fullpath: /g/data/vk83/apps/spack/0.21/release/linux-rocky8-x86_64/intel-2021.10.0/cice5-git.2023.10.19_2023.10.19-5fsgo7ngu72sepcoz4vho5737eiibmkf/bin/cice_auscom_1440x1080_48x40_480p.exe
   hashes:
-    binhash: 22813654d4a52914003c563fa083e245
-    md5: 38bbb933238af1adc63c6d7eb0b6f7d1
+    binhash: 47e978c41be190d4cabcc1a928f3b13b
+    md5: a2de688633ddf65e42335e6490525c92
 work/ocean/fms_ACCESS-OM-BGC.x:
-  fullpath: /g/data/vk83/apps/spack/0.20/release/linux-rocky8-x86_64/intel-19.0.5.281/mom5-git.2023.11.09=2023.11.09-64l5azdtcoxhrgb5ynn2vued5lmjvn33/bin/fms_ACCESS-OM-BGC.x
+  fullpath: /g/data/vk83/apps/spack/0.21/release/linux-rocky8-x86_64/intel-2021.10.0/mom5-git.2024.06.27_2024.06.27-omyzessq2c636dguuzxac6i2onh3rsmf/bin/fms_ACCESS-OM-BGC.x
   hashes:
-    binhash: 45352e33876da49ca042014a9f6686e5
-    md5: a909552e85690be692ad3ec94016181b
+    binhash: d89df46a962b16bd33b61dfbedeb7dcf
+    md5: 14f6f88062bb997eb6313bf454635ea2


### PR DESCRIPTION
This PR updates the executables to the [2024.06.0 ACCESS-OM2-BGC release](https://github.com/ACCESS-NRI/ACCESS-OM2-BGC/releases/tag/2024.06.0):

- spack 0.21
- intel-2021.10.0
- Updated [dependency versions](https://github.com/ACCESS-NRI/ACCESS-OM2-BGC/pull/11)
- MOM5 2024.06.27 (includes [WOMBAT ice-to-ocean BGC coupling bug fix](https://github.com/COSIMA/access-om2/issues/282)) 