### PR TITLE
`config/ci.json`: Added global default `payu-version` `1.1.4`

### DIFF
--- a/.github/workflows/generate-initial-checksums.yml
+++ b/.github/workflows/generate-initial-checksums.yml
@@ -25,7 +25,7 @@ jobs:
     name: Read Testing Configuration
     runs-on: ubuntu-latest
     outputs:
-      python-version: ${{ steps.repro-config.outputs.python-version }}
+      payu-version: ${{ steps.repro-config.outputs.payu-version }}
       model-config-tests-version: ${{ steps.repro-config.outputs.model-config-tests-version }}
     steps:
       - name: Checkout main
@@ -57,7 +57,7 @@ jobs:
     steps:
       - run: |
           echo '::notice::This deployment is using the following inputs: `config-branch-name`=`${{ inputs.config-branch-name }}`, `commit-checksums`=`${{ inputs.commit-checksums }}`, `committed-checksum-location`=`${{ inputs.committed-checksum-location }}`,`committed-checksum-tag-version`=`${{ inputs.committed-checksum-tag-version }}`.'
-          echo '::notice::This deployment is using Python Version ${{ needs.config.outputs.python-version }} and Model Config Tests Version ${{ needs.config.outputs.model-config-tests-version }}'
+          echo '::notice::This deployment is using Payu Version ${{ needs.config.outputs.payu-version }} and Model Config Tests Version ${{ needs.config.outputs.model-config-tests-version }}'
 
   generate-checksums:
     name: Generate Checksums
@@ -72,7 +72,7 @@ jobs:
       committed-checksum-tag: "${{ inputs.config-branch-name }}-${{ inputs.committed-checksum-tag-version }}"
       environment-name: "Gadi Initial Checksum"
       model-config-tests-version: ${{ needs.config.outputs.model-config-tests-version }}
-      python-version: ${{ needs.config.outputs.python-version }}
+      payu-version: ${{ needs.config.outputs.payu-version }}
     permissions:
       contents: write
     secrets: inherit

--- a/README-DEV.md
+++ b/README-DEV.md
@@ -36,7 +36,7 @@ The configuration properties needed to run the tests are:
 | ---- | ---- | ----------- | -------- |
 | markers | `string` | Markers used for the pytest checks, in the python format | `checksum` |
 | model-config-tests-version | `string` | The version of the model-config-tests | `0.0.1` |
-| python-version | `string` | The python version used to create test virtual environment | `3.11.0` |
+| payu-version | `string` | The Payu version used to create test virtual environment | `1.1.4` |
 
 As most of the tests use the same test and python versions, and similar markers, there are two levels of defaults. There's a default at test type level which is useful for defining test markers - this selects certain pytests to run in `model-config-tests`. There is an outer global default, which is used if a property is not defined for a given branch/tag, and it is not defined for the test default. The `parse-ci-config` action applies the fall-back default logic. For more information on using this action see [`ACCESS-NRI/model-config-tests`](https://github.com/ACCESS-NRI/model-config-tests/).
 

--- a/README-DEV.md
+++ b/README-DEV.md
@@ -36,7 +36,8 @@ The configuration properties needed to run the tests are:
 | ---- | ---- | ----------- | -------- |
 | markers | `string` | Markers used for the pytest checks, in the python format | `checksum` |
 | model-config-tests-version | `string` | The version of the model-config-tests | `0.0.1` |
-| payu-version | `string` | The Payu version used to create test virtual environment | `1.1.4` |
+| python-version | `string` | The python version used to create test virtual environment on Github hosted tests | `3.11.0` |
+| payu-version | `string` | The Payu version used to run the model | `1.1.4` |
 
 As most of the tests use the same test and python versions, and similar markers, there are two levels of defaults. There's a default at test type level which is useful for defining test markers - this selects certain pytests to run in `model-config-tests`. There is an outer global default, which is used if a property is not defined for a given branch/tag, and it is not defined for the test default. The `parse-ci-config` action applies the fall-back default logic. For more information on using this action see [`ACCESS-NRI/model-config-tests`](https://github.com/ACCESS-NRI/model-config-tests/).
 

--- a/config/ci.json
+++ b/config/ci.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://github.com/ACCESS-NRI/schema/tree/main/au.org.access-nri/model/configuration/ci/1-0-0.json",
+    "$schema": "https://github.com/ACCESS-NRI/schema/tree/main/au.org.access-nri/model/configuration/ci/2-0-0.json",
     "scheduled": {
         "release-1deg_jra55_ryf-2.0": {},
         "release-1deg_jra55_iaf_bgc-2.0": {},
@@ -19,6 +19,7 @@
     },
     "default": {
         "model-config-tests-version": "0.0.1",
-        "python-version": "3.11.0"
+        "python-version": "3.11.0",
+        "payu-version": "1.1.4"
     }
 }


### PR DESCRIPTION
In this PR:
* Updated `config/ci.json` schema to `2-0-0` - see https://github.com/ACCESS-NRI/schema/pull/35 NOTE: the validation CI will fail until this is merged
* Added global default `payu-version` `1.1.4`

Updated repo settings:
* Added `vars.MODULE_LOCATION` and `vars.PRERELEASE_MODULE_LOCATION`. See https://github.com/ACCESS-NRI/access-om2-configs/settings/environments
* Update `vars.CONFIG_CI_SCHEMA_VERSION` to `2-0-0`. See https://github.com/ACCESS-NRI/access-om2-configs/settings/variables/actions

References ACCESS-NRI/model-config-tests#37