### PR TITLE
Global `payu-version` to `1.1.5`

### DIFF
--- a/config/ci.json
+++ b/config/ci.json
@@ -20,6 +20,6 @@
     "default": {
         "model-config-tests-version": "0.0.1",
         "python-version": "3.11.0",
-        "payu-version": "1.1.4"
+        "payu-version": "1.1.5"
     }
 }


### PR DESCRIPTION
In this PR:
* Update the global `payu-version` from `1.1.4` to `1.1.5` because we are deleting `1.1.4` from Gadi to recover `inodes`

