### PR TITLE
Remove Known Unreproducible Scheduled BGC Config Tag `iaf_bgc-2.0`, Add Post-Fix Config Tag `iaf_bgc-3.0`

### DIFF
--- a/config/ci.json
+++ b/config/ci.json
@@ -2,7 +2,7 @@
     "$schema": "https://github.com/ACCESS-NRI/schema/tree/main/au.org.access-nri/model/configuration/ci/2-0-0.json",
     "scheduled": {
         "release-1deg_jra55_ryf-2.0": {},
-        "release-1deg_jra55_iaf_bgc-2.0": {},
+        "release-1deg_jra55_iaf_bgc-3.0": {},
         "default": {
             "markers": "checksum"
         }


### PR DESCRIPTION
References #158
Closes #161
Closes #160
Closes #157
Closes #154
Closes #149
Closes #145
Closes #144
Closes #138
Closes #135
Closes #113
Closes #112

## Background

We have been constantly scheduled testing a Config Tag that is known to be not restart-reproducible with itself.

In this PR:
 - Remove the `release-1deg_jra55_iaf_bgc-2.0` Scheduled Config Tag as it is known to be unreproducible - see https://github.com/ACCESS-NRI/access-om2-configs/pull/132#issuecomment-2219707510
 - Add the later `release-1deg_jra55_iaf_bgc-3.0` which incorporates this fix https://github.com/ACCESS-NRI/access-om2-configs/pull/132 

