### PR TITLE
Remove `release-1deg_jra55_iaf_bgc-3.0` from scheduled testing due to non-reproducibility

### DIFF
--- a/config/ci.json
+++ b/config/ci.json
@@ -2,7 +2,6 @@
     "$schema": "https://github.com/ACCESS-NRI/schema/tree/main/au.org.access-nri/model/configuration/ci/2-0-0.json",
     "scheduled": {
         "release-1deg_jra55_ryf-2.0": {},
-        "release-1deg_jra55_iaf_bgc-3.0": {},
         "default": {
             "markers": "checksum"
         }


### PR DESCRIPTION
Closes #163

## Background

The config tag being removed isn't restart reproducible, so we shouldn't test it - it will have different answers every time. Once this is fixed (generic tracer support implemented into ACCESS-OM2) we can add `*_bgc` config tags back to scheduled testing. Thanks @dougiesquire for illuminating the matter! :smile: 

In this PR:

* Remove `release-1deg_jra55_iaf_bgc-3.0` from scheduled testing, because it is not restart reproducible anyway. 
