### PR TITLE
Update CI test markers

### DIFF
--- a/config/ci.json
+++ b/config/ci.json
@@ -3,12 +3,12 @@
     "scheduled": {
         "release-1deg_jra55_ryf-2.0": {},
         "default": {
-            "markers": "checksum"
+            "markers": "repro and (not slow)"
         }
     },
     "reproducibility": {
         "default": {
-            "markers": "checksum"
+            "markers": "repro and (not slow)"
         }
     },
     "qa": {
@@ -17,7 +17,7 @@
         }
     },
     "default": {
-        "model-config-tests-version": "0.0.1",
+        "model-config-tests-version": "0.1.0",
         "python-version": "3.11.0",
         "payu-version": "1.1.5"
     }


### PR DESCRIPTION
This PR updates the version of `model-config-tests` used by the CI and updates the marker names according to https://github.com/ACCESS-NRI/model-config-tests/pull/137.