### PR TITLE
Update dev-01deg_jra55_ryf to pass latest QA tests

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -18,6 +18,13 @@ sync:
     enable: False # set path below and change to true
     path: null # Set to location on /g/data or a remote server and path (rsync syntax)
 
+# Modules for loading model executables
+modules:
+  use:
+      - /g/data/vk83/modules
+  load:
+      - access-om2/2024.03.0
+
 # Model configuration
 name: common
 model: access-om2
@@ -28,7 +35,7 @@ input:
 submodels:
     - name: atmosphere
       model: yatm
-      exe: /g/data/vk83/apps/spack/0.20/release/linux-rocky8-x86_64/intel-19.0.5.281/libaccessom2-git.2023.10.26=2023.10.26-ltfg7jcn6t4cefotvj3kjnyu5nru26xo/bin/yatm.exe
+      exe: yatm.exe
       input:
             - /g/data/vk83/experiments/inputs/access-om2/remapping_weights/JRA55/global.01deg/2020.05.30/rmp_jrar_to_cict_CONSERV.nc
             - /g/data/vk83/experiments/inputs/JRA-55/RYF/v1-4/data
@@ -36,7 +43,7 @@ submodels:
 
     - name: ocean
       model: mom
-      exe: /g/data/vk83/apps/spack/0.20/release/linux-rocky8-x86_64/intel-19.0.5.281/mom5-git.2023.11.09=2023.11.09-qji4nlmr6utrribaiyhewe4je6mifguz/bin/fms_ACCESS-OM.x
+      exe: fms_ACCESS-OM.x
       input: 
           - /g/data/vk83/experiments/inputs/access-om2/ocean/grids/mosaic/global.01deg/2020.05.30/grid_spec.nc
           - /g/data/vk83/experiments/inputs/access-om2/ocean/grids/mosaic/global.01deg/2020.05.30/ocean_hgrid.nc
@@ -55,7 +62,7 @@ submodels:
 
     - name: ice
       model: cice5
-      exe: /g/data/vk83/apps/spack/0.20/release/linux-rocky8-x86_64/intel-19.0.5.281/cice5-git.2023.10.19=2023.10.19-v3zncpqjj2gyseudbwiudolcjq3k3leo/bin/cice_auscom_3600x2700_90x90_722p.exe
+      exe: cice_auscom_3600x2700_90x90_722p.exe
       input:
         - /g/data/vk83/experiments/inputs/access-om2/ice/grids/global.01deg/2024.04.17/grid.nc
         - /g/data/vk83/experiments/inputs/access-om2/ice/grids/global.01deg/2024.04.17/kmt.nc

--- a/manifests/input.yaml
+++ b/manifests/input.yaml
@@ -2,183 +2,183 @@ format: yamanifest
 version: 1.0
 ---
 work/INPUT/rmp_jra55_cice_1st_conserve.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-om2/remapping_weights/JRA55/global.01deg/2020.05.30/rmp_jra55_cice_1st_conserve.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-om2/remapping_weights/JRA55/global.01deg/2020.05.30/rmp_jra55_cice_1st_conserve.nc
   hashes:
-    binhash: c7710f6bfdf6221c8bca405d07b1bf70
+    binhash: aa4f927c4c81fa9bce8b9a2d034ba583
     md5: 16d69cca9d8e327ffa99f6569c857096
 work/INPUT/rmp_jra55_cice_2nd_conserve.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-om2/remapping_weights/JRA55/global.01deg/2020.05.30/rmp_jra55_cice_2nd_conserve.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-om2/remapping_weights/JRA55/global.01deg/2020.05.30/rmp_jra55_cice_2nd_conserve.nc
   hashes:
-    binhash: cc9701ab595d9676ab7d1fc28a7befab
+    binhash: a23fa2cb922b33d1e4bcaf54ecc264bb
     md5: 43349f57a2fdaec9556bf7b6a51e3978
 work/INPUT/rmp_jra55_cice_patch.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-om2/remapping_weights/JRA55/global.01deg/2020.05.30/rmp_jra55_cice_patch.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-om2/remapping_weights/JRA55/global.01deg/2020.05.30/rmp_jra55_cice_patch.nc
   hashes:
-    binhash: 96fc5d2ffa46b14e4369d8e1a1cee1fc
+    binhash: 42c45c3c1c9847d45d6aae8bebfa3790
     md5: 3d62f2c7dbbf18734bdb2f7395daa607
 work/atmosphere/INPUT/RYF.friver.1990_1991.nc:
-  fullpath: /g/data/vk83/experiments/inputs/JRA-55/RYF/v1-4/data/RYF.friver.1990_1991.nc
+  fullpath: /g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.friver.1990_1991.nc
   hashes:
-    binhash: df5b6715e020f563acb65673571a565f
+    binhash: abba207de30541a83d25e24b424cfa87
     md5: fa3a55aeb6706a1b422d096f61a772c1
 work/atmosphere/INPUT/RYF.huss.1990_1991.nc:
-  fullpath: /g/data/vk83/experiments/inputs/JRA-55/RYF/v1-4/data/RYF.huss.1990_1991.nc
+  fullpath: /g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.huss.1990_1991.nc
   hashes:
-    binhash: 71d6099511ebc8b43f9b86b325ecf3af
+    binhash: 1d67d219c6f161051dec204a1842a968
     md5: 6032d514fdfdd2b6a84bdef0a4ac3afe
 work/atmosphere/INPUT/RYF.licalvf.1990_1991.nc:
-  fullpath: /g/data/vk83/experiments/inputs/JRA-55/RYF/v1-4/data/RYF.licalvf.1990_1991.nc
+  fullpath: /g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.licalvf.1990_1991.nc
   hashes:
-    binhash: f219ce98f3fcbe6f8ec517740f01aee1
+    binhash: 834da0a081e904fdbc892255d1954062
     md5: 6f927702cbc023cc20d3ddd69695f0a0
 work/atmosphere/INPUT/RYF.prra.1990_1991.nc:
-  fullpath: /g/data/vk83/experiments/inputs/JRA-55/RYF/v1-4/data/RYF.prra.1990_1991.nc
+  fullpath: /g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.prra.1990_1991.nc
   hashes:
-    binhash: 2754bd49fff02bf5330a086310f1c296
+    binhash: 7bc006b83a9891d4f9ef39f4d94ffb05
     md5: ac199086106ec4e41506e6082bccb109
 work/atmosphere/INPUT/RYF.prsn.1990_1991.nc:
-  fullpath: /g/data/vk83/experiments/inputs/JRA-55/RYF/v1-4/data/RYF.prsn.1990_1991.nc
+  fullpath: /g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.prsn.1990_1991.nc
   hashes:
-    binhash: 154a15cde4940309ac5e6fef0d7faba4
+    binhash: a57a154152a830ad1ca820ca9487d5ac
     md5: cd076c877c2c5df61615e04d71ed00e0
 work/atmosphere/INPUT/RYF.psl.1990_1991.nc:
-  fullpath: /g/data/vk83/experiments/inputs/JRA-55/RYF/v1-4/data/RYF.psl.1990_1991.nc
+  fullpath: /g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.psl.1990_1991.nc
   hashes:
-    binhash: 559b1e3183475cfb94a7f013f4acf8ea
+    binhash: 420c371361bb677eb87c01255c6e62b3
     md5: 0dfd94a5c3234fd2016dfdd01e84a170
 work/atmosphere/INPUT/RYF.rhuss.1990_1991.nc:
-  fullpath: /g/data/vk83/experiments/inputs/JRA-55/RYF/v1-4/data/RYF.rhuss.1990_1991.nc
+  fullpath: /g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.rhuss.1990_1991.nc
   hashes:
-    binhash: 1f70c237032f7368e6f2478d2a678c99
+    binhash: fe4460b8d68f94df26adc52fb56a0d6a
     md5: 632519955305cb5c19e286b151439fb5
 work/atmosphere/INPUT/RYF.rlds.1990_1991.nc:
-  fullpath: /g/data/vk83/experiments/inputs/JRA-55/RYF/v1-4/data/RYF.rlds.1990_1991.nc
+  fullpath: /g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.rlds.1990_1991.nc
   hashes:
-    binhash: 9512836673a68507bed403ecd859ba38
+    binhash: 07a7fb6f9d2a3aee4081034f0cfc305a
     md5: 0ea83e107ec883c3f39a12b60ff50d8e
 work/atmosphere/INPUT/RYF.rsds.1990_1991.nc:
-  fullpath: /g/data/vk83/experiments/inputs/JRA-55/RYF/v1-4/data/RYF.rsds.1990_1991.nc
+  fullpath: /g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.rsds.1990_1991.nc
   hashes:
-    binhash: 7ff7cd79ace33fefe2b9a91ea018ea14
+    binhash: 2d6c41b66024e460fcfe0a1668bfe151
     md5: b74bf123f1e4557368a61732cf24f1c2
 work/atmosphere/INPUT/RYF.tas.1990_1991.nc:
-  fullpath: /g/data/vk83/experiments/inputs/JRA-55/RYF/v1-4/data/RYF.tas.1990_1991.nc
+  fullpath: /g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.tas.1990_1991.nc
   hashes:
-    binhash: 8f3c6798cc92a1d0b6573eb44b2a4dd2
+    binhash: 2a7a2f9903346123161b91ed8d5fab52
     md5: 06689885f4f2f726b95a2818ab78a20d
 work/atmosphere/INPUT/RYF.uas.1990_1991.nc:
-  fullpath: /g/data/vk83/experiments/inputs/JRA-55/RYF/v1-4/data/RYF.uas.1990_1991.nc
+  fullpath: /g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.uas.1990_1991.nc
   hashes:
-    binhash: 54ede2172bf85bc861bc64c296a03f8c
+    binhash: bfd4876aac0b31e51a18c7724c84d8b1
     md5: 107bf9480f55597655d2d283b6f6b4ff
 work/atmosphere/INPUT/RYF.vas.1990_1991.nc:
-  fullpath: /g/data/vk83/experiments/inputs/JRA-55/RYF/v1-4/data/RYF.vas.1990_1991.nc
+  fullpath: /g/data/vk83/configurations/inputs/JRA-55/RYF/v1-4/data/RYF.vas.1990_1991.nc
   hashes:
-    binhash: 17224eecb745b6ce72604b41201c1fe7
+    binhash: d15ca562e37e82fb2d31657701f0a560
     md5: 88dc8c70338bbc8f5efc48ed0009a99f
 work/atmosphere/INPUT/rmp_jrar_to_cict_CONSERV.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-om2/remapping_weights/JRA55/global.01deg/2020.05.30/rmp_jrar_to_cict_CONSERV.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-om2/remapping_weights/JRA55/global.01deg/2020.05.30/rmp_jrar_to_cict_CONSERV.nc
   hashes:
-    binhash: 16b59e31f2618d9b4df7e907dc11fb25
+    binhash: 2781aaa1d02deebc2bcbe73d1a1d965d
     md5: 08f3f762a1b005d4ba90f5ceef5ccc74
 work/ice/RESTART/grid.nc:
   copy: true
-  fullpath: /g/data/vk83/experiments/inputs/access-om2/ice/grids/global.01deg/2024.04.17/grid.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-om2/ice/grids/global.01deg/2024.04.17/grid.nc
   hashes:
-    binhash: d71c0256388855eb6c2e7ab27997fdde
+    binhash: 9ce4e8cd9dac326135823175fba8302f
     md5: ab3458bf0c16cc5e2e72f59b705de313
 work/ice/RESTART/i2o.nc:
   copy: true
-  fullpath: /g/data/vk83/experiments/inputs/access-om2/ice/initial_conditions/global.01deg/2020.05.30/i2o.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-om2/ice/initial_conditions/global.01deg/2020.05.30/i2o.nc
   hashes:
-    binhash: c28de3c40c243977d02a6d4672807038
+    binhash: 629d52261991b0416d0657c8f320e41d
     md5: a118ccf1a07bf31676e038e3c2b6c964
 work/ice/RESTART/kmt.nc:
   copy: true
-  fullpath: /g/data/vk83/experiments/inputs/access-om2/ice/grids/global.01deg/2024.04.17/kmt.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-om2/ice/grids/global.01deg/2024.04.17/kmt.nc
   hashes:
-    binhash: f17083b7d13413de60466ba220b05860
+    binhash: 9c5cf23bf4f5490c5e7c2c2e8177568d
     md5: 8c12f286b56ff171287753986e72d5cb
 work/ice/RESTART/monthly_sstsss.nc:
   copy: true
-  fullpath: /g/data/vk83/experiments/inputs/access-om2/ice/initial_conditions/global.01deg/2020.05.30/monthly_sstsss.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-om2/ice/initial_conditions/global.01deg/2020.05.30/monthly_sstsss.nc
   hashes:
-    binhash: 59d46726887afc66225c8bdfa6a25d5b
+    binhash: b3f7ea92fc45f2c7f7a8f3a2b128be32
     md5: e00d77cf7b519d9bbcfc8bea2e34ef8f
 work/ice/RESTART/o2i.nc:
   copy: true
-  fullpath: /g/data/vk83/experiments/inputs/access-om2/ice/initial_conditions/global.01deg/2020.05.30/o2i.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-om2/ice/initial_conditions/global.01deg/2020.05.30/o2i.nc
   hashes:
-    binhash: 8ea25776dc6684070214a9f1e041b114
+    binhash: 18846a13e8d18c2478d060870ca55e95
     md5: a08c3c2c2f7668732f64347adc6c20cb
 work/ice/RESTART/u_star.nc:
   copy: true
-  fullpath: /g/data/vk83/experiments/inputs/access-om2/ice/initial_conditions/global.01deg/2020.05.30/u_star.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-om2/ice/initial_conditions/global.01deg/2020.05.30/u_star.nc
   hashes:
-    binhash: 6eae42f2ab0164f2b3df10292649abae
+    binhash: b0fa2f57ceef0fd228656d6f22e7cf57
     md5: e34bf0c92d0585cfc2d90de32af35e43
 work/ocean/INPUT/chl.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-om2/ocean/chlorophyll/global.01deg/2020.05.30/chl.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-om2/ocean/chlorophyll/global.01deg/2020.05.30/chl.nc
   hashes:
-    binhash: c33b83b1f3f3b92ab7390b4c9888820f
+    binhash: 636069ff9b90513d567527dbd6cab317
     md5: 8cc506303102f2faad01b8ffb5268bf5
 work/ocean/INPUT/grid_spec.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-om2/ocean/grids/mosaic/global.01deg/2020.05.30/grid_spec.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-om2/ocean/grids/mosaic/global.01deg/2020.05.30/grid_spec.nc
   hashes:
-    binhash: 22d51e6d15b1247123786da5e0672578
+    binhash: c3f48cfe9a3e7dfe99e386ff692514f0
     md5: cb5674cf1d2be64b3c5c1eac948e51d7
 work/ocean/INPUT/ocean_hgrid.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-om2/ocean/grids/mosaic/global.01deg/2020.05.30/ocean_hgrid.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-om2/ocean/grids/mosaic/global.01deg/2020.05.30/ocean_hgrid.nc
   hashes:
-    binhash: 282a7825f7adaeb85c5ba0960eac23ed
+    binhash: 17070da7b784c523b49d287ec4ade88c
     md5: c6d7acf7fe7d6df5d5b72ebf37d11f90
 work/ocean/INPUT/ocean_mask.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-om2/ocean/grids/bathymetry/global.01deg/2020.05.30/ocean_mask.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-om2/ocean/grids/bathymetry/global.01deg/2020.05.30/ocean_mask.nc
   hashes:
-    binhash: f4d3075cdf2f573ec35e0b8ba3084840
+    binhash: 69e50446fcdcbb2c3cef6e0a772cef8e
     md5: 7868653fbcc22b1654a6ace0e3b15763
 work/ocean/INPUT/ocean_mask_table:
-  fullpath: /g/data/vk83/experiments/inputs/access-om2/ocean/processor_masks/global.01deg/4358.80x75/2020.05.30/ocean_mask_table
+  fullpath: /g/data/vk83/configurations/inputs/access-om2/ocean/processor_masks/global.01deg/4358.80x75/2020.05.30/ocean_mask_table
   hashes:
-    binhash: 0d7bf8ddaed8d64b2bc51ab9abfb548c
+    binhash: 3bd372bf33786d0a8911497bdbeb7729
     md5: baca6cd1163063135e0fcb3c343bb5e6
 work/ocean/INPUT/ocean_mosaic.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-om2/ocean/grids/mosaic/global.01deg/2020.05.30/ocean_mosaic.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-om2/ocean/grids/mosaic/global.01deg/2020.05.30/ocean_mosaic.nc
   hashes:
-    binhash: 76f3b517569d70bd5d2e50acc1f6aa8e
+    binhash: 6b62f2c9291d0b10f199261e062e9c2f
     md5: 1263df68b94e7a256be52283df611e94
 work/ocean/INPUT/ocean_temp_salt.res.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-om2/ocean/initial_conditions/global.01deg/2020.10.22/ocean_temp_salt.res.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-om2/ocean/initial_conditions/global.01deg/2020.10.22/ocean_temp_salt.res.nc
   hashes:
-    binhash: 632af80792f66b78a0bc95f53eb8a988
+    binhash: 8bef91757be41aa1f747ecb2ba0b498d
     md5: 7e3671bdd8e1732b55eb3f9eeb5f614a
 work/ocean/INPUT/ocean_vgrid.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-om2/ocean/grids/vertical/global.01deg/2020.05.30/ocean_vgrid.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-om2/ocean/grids/vertical/global.01deg/2020.05.30/ocean_vgrid.nc
   hashes:
-    binhash: 6702a7ca40775e2722264d372aa1ffbb
+    binhash: 1d44582b3ffd2f708e0b708ae172ae43
     md5: 31d7de8345a0bab0ee004915aa36027a
 work/ocean/INPUT/roughness_amp.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-om2/ocean/tides/global.01deg/2020.05.30/roughness_amp.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-om2/ocean/tides/global.01deg/2020.05.30/roughness_amp.nc
   hashes:
-    binhash: 650dc6489e1b3785813dba278f177dc9
+    binhash: c6f847c4f0ce8610d2e16f47e2a8c898
     md5: f13792f9f45097086da030ff83035f27
 work/ocean/INPUT/roughness_cdbot.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-om2/ocean/tides/global.01deg/2020.05.30/roughness_cdbot.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-om2/ocean/tides/global.01deg/2020.05.30/roughness_cdbot.nc
   hashes:
-    binhash: 6ca7d157175d4550e81ab57aeb7f7684
+    binhash: d9e19e92c13f73fc174be92ac59d219b
     md5: a690972610c4d6c20388f44bde3e9837
 work/ocean/INPUT/salt_sfc_restore.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-om2/ocean/surface_salt_restoring/global.01deg/2020.05.30/salt_sfc_restore.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-om2/ocean/surface_salt_restoring/global.01deg/2020.05.30/salt_sfc_restore.nc
   hashes:
-    binhash: fd2784b76ceae2dedcfe2e0d12978b44
+    binhash: 69e0c2214202c660d9fd040b33ce0703
     md5: 61bff26084d7efa9423bb14fe3bc9347
 work/ocean/INPUT/tideamp.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-om2/ocean/tides/global.01deg/2020.05.30/tideamp.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-om2/ocean/tides/global.01deg/2020.05.30/tideamp.nc
   hashes:
-    binhash: ca509f32cc8305cd186b9f2eabe8bfbb
+    binhash: 654a960d1eb55a632277517485d2a494
     md5: 92a791452244947a7a393e8ff489c5bb
 work/ocean/INPUT/topog.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-om2/ocean/grids/bathymetry/global.01deg/2020.05.30/topog.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-om2/ocean/grids/bathymetry/global.01deg/2020.05.30/topog.nc
   hashes:
-    binhash: faa894b0c4b078205b05a75d4ee654c2
+    binhash: 3a4546c712c9848ed0edd4c58efcc1d5
     md5: 1e69c16bd3a2fd335a746ff30fe7cc84

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -17,14 +17,7 @@ notes: |-
   https://docs.google.com/spreadsheets/d/18BDyZlHTSy6EOaf_5o9CwGBOu4pBj88XsS2vNW4R_2o
   (b) consider citing Kiss et al. (2020) [http://doi.org/10.5194/gmd-13-401-2020] and papers describing relevant
   configuration updates - see https://forum.access-hive.org.au/t/access-om2-control-experiments/258
-  (c) include an acknowledgement such as the following (replacing/deleting text in angle brackets as needed):
-  "This work was supported by computational resources provided by the Australian Government through the
-  National Computational Infrastructure (NCI) under the <National Computational Merit Allocation Scheme>
-  and/or <ANU Merit Allocation Scheme>. We thank the vibrant communities of the Consortium for Ocean–Sea Ice
-  Modelling in Australia (COSIMA; cosima.org.au) and the Australian Community Climate and Earth System Simulator
-  National Research Infrastructure (ACCESS-NRI; access-nri.org.au) for making the ACCESS-OM2 <models> and/or
-  <outputs> and/or <analysis tools> available through the NCI. COSIMA is funded through the Australian Research
-  Council grant LP200100406."
+  (c) include an acknowledgement such as that suggested here: https://cosima.org.au/index.php/get-involved/
   (d) let COSIMA know of any publications which use these models or data so they can add them to their list:
   https://scholar.google.com/citations?hl=en&user=inVqu_4AAAAJ
   (e) Tell ACCESS-NRI that you are using ACCESS-NRI infrastructure: https://www.access-nri.org.au/resources/user-reporting/

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -41,4 +41,4 @@ nominal_resolution: 10 km
 reference: https://doi.org/10.5194/gmd-13-401-2020
 license: CC-BY-4.0
 url: https://github.com/ACCESS-NRI/access-om2-configs/tree/release-01deg_jra55_ryf
-model: access-om2-01
+model: ACCESS-OM2

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -13,14 +13,21 @@ description: |-
   Spin up starts from a nominal year of 1 Jan 1900.
 notes: |-
   COSIMA request that users of this or other ACCESS-OM2 model code or output data:
-  (a) consider citing Kiss et al. (2020) [http://doi.org/10.5194/gmd-13-401-2020]
-  (b) include an acknowledgement such as the following:
-  "The authors thank the Consortium for Ocean-Sea Ice Modelling in Australia (COSIMA; http://www.cosima.org.au)
-  for making the ACCESS-OM2 suite of models available at https://github.com/COSIMA/access-om2.
-  Model runs were undertaken with the assistance of resources from the National Computational Infrastructure (NCI),
-  which is supported by the Australian Government."
-  (c) let COSIMA know of any publications which use these models or data so they can add them to their list:
+  (a) add a project description to COSIMA's list:
+  https://docs.google.com/spreadsheets/d/18BDyZlHTSy6EOaf_5o9CwGBOu4pBj88XsS2vNW4R_2o
+  (b) consider citing Kiss et al. (2020) [http://doi.org/10.5194/gmd-13-401-2020] and papers describing relevant
+  configuration updates - see https://forum.access-hive.org.au/t/access-om2-control-experiments/258
+  (c) include an acknowledgement such as the following (replacing/deleting text in angle brackets as needed):
+  "This work was supported by computational resources provided by the Australian Government through the
+  National Computational Infrastructure (NCI) under the <National Computational Merit Allocation Scheme>
+  and/or <ANU Merit Allocation Scheme>. We thank the vibrant communities of the Consortium for Ocean–Sea Ice
+  Modelling in Australia (COSIMA; cosima.org.au) and the Australian Community Climate and Earth System Simulator
+  National Research Infrastructure (ACCESS-NRI; access-nri.org.au) for making the ACCESS-OM2 <models> and/or
+  <outputs> and/or <analysis tools> available through the NCI. COSIMA is funded through the Australian Research
+  Council grant LP200100406."
+  (d) let COSIMA know of any publications which use these models or data so they can add them to their list:
   https://scholar.google.com/citations?hl=en&user=inVqu_4AAAAJ
+  (e) Tell ACCESS-NRI that you are using ACCESS-NRI infrastructure: https://www.access-nri.org.au/resources/user-reporting/
 keywords:
   - global
   - JRA55


### PR DESCRIPTION
Updated configuration to pass latest version of CI QA tests in [model-config-tests](https://github.com/ACCESS-NRI/model-config-tests/) by adding module use/load for model executables.

Tested manually with `model-config-tests` installed from `main` branch with `payu/dev` environment. Ran `payu setup` to double check no md5 hashes changed.

References https://github.com/ACCESS-NRI/access-om2-configs/issues/166