### PR TITLE
Add checks: write permission

### DIFF
--- a/.github/workflows/generate-initial-checksums.yml
+++ b/.github/workflows/generate-initial-checksums.yml
@@ -75,4 +75,5 @@ jobs:
       payu-version: ${{ needs.config.outputs.payu-version }}
     permissions:
       contents: write
+      checks: write
     secrets: inherit


### PR DESCRIPTION
References ACCESS-NRI/access-esm1.6-configs#73

## Background

Similar to the linked issue, a later workflow requires `permissions.checks: write` but we don't give that in the caller. Now we do!

## The PR

* Give `repro-ci` `permissions.checks: write`

