### PR TITLE
Update CI config model-config-tests version to 0.2.0

### DIFF
--- a/config/ci.json
+++ b/config/ci.json
@@ -17,7 +17,7 @@
         }
     },
     "default": {
-        "model-config-tests-version": "0.1.0",
+        "model-config-tests-version": "0.2.0",
         "python-version": "3.11.0",
         "payu-version": "1.1.5"
     }


### PR DESCRIPTION
Update CI configuration to use the `model-config-test` version [0.2.0](https://github.com/ACCESS-NRI/model-config-tests/releases/tag/v0.2.0) that includes extra tests for expected model name and expected notes in `metadata.yaml` so they are consistent across every ACCESS-OM2 configuration.

