### PR TITLE
Update CI config model-config-tests version to 0.2.3

### DIFF
--- a/config/ci.json
+++ b/config/ci.json
@@ -17,7 +17,7 @@
         }
     },
     "default": {
-        "model-config-tests-version": "0.2.0",
+        "model-config-tests-version": "0.2.3",
         "python-version": "3.11.0",
         "payu-version": "1.1.5"
     }


### PR DESCRIPTION
[`model-config-tests` v0.2.3](https://github.com/ACCESS-NRI/model-config-tests/releases/tag/v0.2.3) includes [this fix](https://github.com/ACCESS-NRI/model-config-tests/pull/193) which will fix the failing CI in these PRs:

- https://github.com/ACCESS-NRI/access-om2-configs/pull/219
- https://github.com/ACCESS-NRI/access-om2-configs/pull/220
- https://github.com/ACCESS-NRI/access-om2-configs/pull/221
- https://github.com/ACCESS-NRI/access-om2-configs/pull/222