### PR TITLE
Fix typo in README.md link to branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Some examples of possible values of the specifiers:
 
 ## Supported configurations
 
-All available configurations are browsable under [the list of branches](https://github.com/ACCESS-NRI/accessom2-configs/branches).
+All available configurations are browsable under [the list of branches](https://github.com/ACCESS-NRI/access-om2-configs/branches).
 
 and should also be listed below:
 


### PR DESCRIPTION
Minor typo in a link to branches on README.