### PR TITLE
ci.json: Update markers for repro tests

### DIFF
--- a/config/ci.json
+++ b/config/ci.json
@@ -8,7 +8,7 @@
     },
     "reproducibility": {
         "default": {
-            "markers": "repro and (not slow)"
+            "markers": "repro"
         }
     },
     "qa": {


### PR DESCRIPTION
With this change `!test repro` runs all repro markers for all configs.

I've recently discovered that 0.25deg configs are not restart reproducible. I'll open an issue about this, but it would be helpful to have the change in this PR first for demonstrating and testing the issue. Once we resolve the issue with the 0.25deg configurations, I'll also update the markers for the `scheduled` checks.