### PR TITLE
Set payu_minimum_version=1.2.1: `dev-1deg_jra55_iaf`

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -118,3 +118,5 @@ userscripts:
     error: tools/resub.sh
     run: rm -f resubmit.count
     sync: /g/data/vk83/apps/om2-scripts/concatenate_ice/concat_ice_daily.sh
+
+payu_minimum_version: 1.2.1


### PR DESCRIPTION
This PR sets  `payu_minimum_version: 1.2.1` in the `config.yaml`. This is to ensure that this [Payu change](https://github.com/payu-org/payu/pull/647) is available to prevent failures at collation.

See #242 