### PR TITLE
Set agm_read_restart = .true.: `dev-025deg_jra55_iaf`

### DIFF
--- a/ocean/input.nml
+++ b/ocean/input.nml
@@ -254,6 +254,7 @@
     agm_closure_upper_depth = 100.0
     aredi             = 200.0
     aredi_diffusivity_grid_scaling = .true.
+    agm_read_restart  = .true.
     aredi_equal_agm   = .false.
     drhodz_mom4p1     = .true.
     nphysics_util_zero_init = .true.


### PR DESCRIPTION
This PR adds in `ocean/input.nml`:

```diff
&ocean_nphysics_util_nml
+    agm_read_restart  = .true.
```

making the configuration restart reproducible.

See #245