### PR TITLE
Update versions of payu and model-config-tests used by CI

### DIFF
--- a/config/ci.json
+++ b/config/ci.json
@@ -4,7 +4,7 @@
         "release-1deg_jra55_ryf-2.0": {},
         "default": {
             "markers": "repro and (not slow)"
-        }
+        },
         "release-.*": {
             "model-config-tests-version": "0.2.3",
             "payu-version": "1.2.1"
@@ -13,7 +13,7 @@
     "reproducibility": {
         "default": {
             "markers": "repro"
-        }
+        },
         "release-.*": {
             "model-config-tests-version": "0.2.3",
             "payu-version": "1.2.1"
@@ -22,7 +22,7 @@
     "qa": {
         "default": {
             "markers": "access_om2 or config"
-        }
+        },
         "release-.*": {
             "model-config-tests-version": "0.2.3",
             "payu-version": "1.2.1"


### PR DESCRIPTION
This PR updates the CI to use:
- `model-config-tests` "main" branch
- `payu` "dev" branch

This is the same as what we do in `access-om3-configs`