### PR TITLE
Updates for next release: `dev-01deg_jra55_iaf`

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,13 @@ For usage instructions, see the [ACCESS-Hive docs](https://access-hive.org.au/mo
 
 Run length and timestep are set in `accessom2.nml`. The configuration is supplied with a 300s timestep which is stable for a startup from rest, but very slow. **After the model has equilibrated for a few months you should increase the timestep to 450s and then to 540s** for improved throughput. You may even find it runs stably at 600s.
 
+## Performance
+
+The approximate cost of running this configuration without modification is:
+- Compute usage: 162 kSU/year
+- Model throughput: 1.5 years/day
+- Total CPUs: 5088
+
 ## Conditions of use
 
 COSIMA requests that users of this or other ACCESS-OM2 model code:

--- a/atmosphere/forcing.json
+++ b/atmosphere/forcing.json
@@ -1,59 +1,59 @@
 {
-  "description": "JRA55-do v1.4.0 IAF forcing",
+  "description": "JRA55-do v1.6.0 IAF forcing",
   "inputs": [
     {
-      "filename": "INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_{{year}}01010130-{{year}}12312230.nc",
+      "filename": "INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_{{year}}01010130-{{year}}12312230.nc",
       "fieldname": "rsds",
       "cname": "swfld_ai"
     },
     {
-      "filename": "INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_{{year}}01010130-{{year}}12312230.nc",
+      "filename": "INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_{{year}}01010130-{{year}}12312230.nc",
       "fieldname": "rlds",
       "cname": "lwfld_ai"
     },
     {
-      "filename": "INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_{{year}}01010130-{{year}}12312230.nc",
+      "filename": "INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_{{year}}01010130-{{year}}12312230.nc",
       "fieldname": "prra",
       "cname": "rain_ai"
     },
     {
-      "filename": "INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_{{year}}01010130-{{year}}12312230.nc",
+      "filename": "INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_{{year}}01010130-{{year}}12312230.nc",
       "fieldname": "prsn",
       "cname": "snow_ai"
     },
     {
-      "filename": "INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_{{year}}01010000-{{year}}12312100.nc",
+      "filename": "INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_{{year}}01010000-{{year}}12312100.nc",
       "fieldname": "psl",
       "cname": "press_ai"
     },
     {
-      "filename": "INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_{{year}}0101-{{year}}1231.nc",
+      "filename": "INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_{{year}}0101-{{year}}1231.nc",
       "fieldname": "friver",
       "cname": "runof_ai",
       "domain": "land"
     },
     {
-      "filename": "INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_{{year}}01010000-{{year}}12312100.nc",
+      "filename": "INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_{{year}}01010000-{{year}}12312100.nc",
       "fieldname": "tas",
       "cname": "tair_ai"
     },
     {
-      "filename": "INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_{{year}}01010000-{{year}}12312100.nc",
+      "filename": "INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_{{year}}01010000-{{year}}12312100.nc",
       "fieldname": "huss",
       "cname": "qair_ai"
     },
     {
-      "filename": "INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_{{year}}01010000-{{year}}12312100.nc",
+      "filename": "INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_{{year}}01010000-{{year}}12312100.nc",
       "fieldname": "uas",
       "cname": "uwnd_ai"
     },
     {
-      "filename": "INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_{{year}}01010000-{{year}}12312100.nc",
+      "filename": "INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_{{year}}01010000-{{year}}12312100.nc",
       "fieldname": "vas",
       "cname": "vwnd_ai"
     },
     {
-      "filename": "INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_{{year}}0101-{{year}}1231.nc",
+      "filename": "INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_{{year}}0101-{{year}}1231.nc",
       "fieldname": "licalvf",
       "cname": "licalvf_ai",
       "domain": "land"

--- a/config.yaml
+++ b/config.yaml
@@ -39,17 +39,17 @@ submodels:
       exe: yatm.exe
       input:
             - /g/data/vk83/configurations/inputs/access-om2/remapping_weights/JRA55/global.01deg/2020.05.30/rmp_jrar_to_cict_CONSERV.nc
-            - /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rsds/gr/v20190429
-            - /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rlds/gr/v20190429
-            - /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prra/gr/v20190429
-            - /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prsn/gr/v20190429
-            - /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/psl/gr/v20190429
-            - /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/land/day/friver/gr/v20190429
-            - /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/tas/gr/v20190429
-            - /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/huss/gr/v20190429
-            - /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/uas/gr/v20190429
-            - /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/vas/gr/v20190429
-            - /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/landIce/day/licalvf/gr/v20190429      
+            - /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531
+            - /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531
+            - /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531
+            - /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531
+            - /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531
+            - /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531
+            - /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531
+            - /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531
+            - /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531
+            - /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531
+            - /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531
       ncpus: 1
 
     - name: ocean

--- a/manifests/input.yaml
+++ b/manifests/input.yaml
@@ -16,3421 +16,3696 @@ work/INPUT/rmp_jra55_cice_patch.nc:
   hashes:
     binhash: 42c45c3c1c9847d45d6aae8bebfa3790
     md5: 3d62f2c7dbbf18734bdb2f7395daa607
-work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19580101-19581231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/land/day/friver/gr/v20190429/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19580101-19581231.nc
-  hashes:
-    binhash: 6baf157803377072d885fb9ffbb192b7
-    md5: 85f7571c1926560c8d5e1d40fea55ca3
-work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19590101-19591231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/land/day/friver/gr/v20190429/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19590101-19591231.nc
-  hashes:
-    binhash: d5a0523973c42aaa08f1e6cc4ec9c184
-    md5: 509c3ca40ddc508a035b34435cc42e17
-work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19600101-19601231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/land/day/friver/gr/v20190429/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19600101-19601231.nc
-  hashes:
-    binhash: 8756251e589cd0e5a92cf0d55db2f780
-    md5: f13cd16ca844833e8297c009af8f330d
-work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19610101-19611231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/land/day/friver/gr/v20190429/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19610101-19611231.nc
-  hashes:
-    binhash: 6440826b08f78abb5bef6705a2d710ff
-    md5: 292c6d74190836159fef0453b81543af
-work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19620101-19621231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/land/day/friver/gr/v20190429/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19620101-19621231.nc
-  hashes:
-    binhash: 27c73a96bbc62ee4f4e7e5c52ca1b27a
-    md5: 3bdb6b8c0be193ee91bd895f9d204b89
-work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19630101-19631231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/land/day/friver/gr/v20190429/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19630101-19631231.nc
-  hashes:
-    binhash: 6357a10310d39fc3b2ed2a212df379fa
-    md5: a52bdae5309b241436352d7a836110d9
-work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19640101-19641231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/land/day/friver/gr/v20190429/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19640101-19641231.nc
-  hashes:
-    binhash: 6968c5c2481f52c3041efef017475084
-    md5: 654014e149a9e5e319ded3870cf37535
-work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19650101-19651231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/land/day/friver/gr/v20190429/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19650101-19651231.nc
-  hashes:
-    binhash: cbe8226ffc1a7cd0de7297c9597e7fe8
-    md5: e329f15895658ff145ced92831514725
-work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19660101-19661231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/land/day/friver/gr/v20190429/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19660101-19661231.nc
-  hashes:
-    binhash: 45474303ac17956f72a868adfa59d271
-    md5: 7fa0c7a24dfc8412f5bb87d460ece212
-work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19670101-19671231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/land/day/friver/gr/v20190429/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19670101-19671231.nc
-  hashes:
-    binhash: 65cf925bce0a22ddb8baf864154077da
-    md5: 706405e07baff89562e1f8f0275b10e3
-work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19680101-19681231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/land/day/friver/gr/v20190429/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19680101-19681231.nc
-  hashes:
-    binhash: 70613c6a3396b0e3da4962deb2bf03a6
-    md5: 6eebcb9fefe653b434e6b5017af6a827
-work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19690101-19691231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/land/day/friver/gr/v20190429/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19690101-19691231.nc
-  hashes:
-    binhash: c8aede62f2e772c4b6f3ab5bb5ada18e
-    md5: d156cc47cf83235fe2beb6910778bf3b
-work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19700101-19701231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/land/day/friver/gr/v20190429/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19700101-19701231.nc
-  hashes:
-    binhash: 6ddf9473a1b114a0a6c29d4808ce7d82
-    md5: d214a7d5a9fe56a28963ff414d97b694
-work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19710101-19711231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/land/day/friver/gr/v20190429/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19710101-19711231.nc
-  hashes:
-    binhash: b83ed63785e2dd2ab02bcaa97306a3a5
-    md5: fb5c25610da65d1fb672813120a735a4
-work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19720101-19721231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/land/day/friver/gr/v20190429/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19720101-19721231.nc
-  hashes:
-    binhash: 1c3cc665e46a7d16b6e6c9c2ab4c7198
-    md5: 00c2f6aa9163049d8148e43dcd859c04
-work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19730101-19731231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/land/day/friver/gr/v20190429/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19730101-19731231.nc
-  hashes:
-    binhash: bc2349e769b3c26b06a7c3d7d33bd2ab
-    md5: ba49d2185768db4350b465443e8eec2f
-work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19740101-19741231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/land/day/friver/gr/v20190429/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19740101-19741231.nc
-  hashes:
-    binhash: 8015208001f1fa3cc7658ad36c0e03aa
-    md5: ae49991379328f3a5f1b162a64022cfc
-work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19750101-19751231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/land/day/friver/gr/v20190429/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19750101-19751231.nc
-  hashes:
-    binhash: d72a2c05f11cd12d9022199024332006
-    md5: c55f8f2d4fbf7a8cee8284b10ded8f0a
-work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19760101-19761231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/land/day/friver/gr/v20190429/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19760101-19761231.nc
-  hashes:
-    binhash: c028df81ed8397f38634a7b76cbb526a
-    md5: 35f90d1879e1a8f2f19ec5b9015221b2
-work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19770101-19771231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/land/day/friver/gr/v20190429/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19770101-19771231.nc
-  hashes:
-    binhash: aa0913b8c503215569d24677209190cd
-    md5: 1c06ae13777dfbe907a911d2bbd04b13
-work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19780101-19781231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/land/day/friver/gr/v20190429/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19780101-19781231.nc
-  hashes:
-    binhash: 63eee9f02077ce726bd303a8274fbbbc
-    md5: 34962ae8c3f138afe3b9181b0c3481c1
-work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19790101-19791231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/land/day/friver/gr/v20190429/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19790101-19791231.nc
-  hashes:
-    binhash: 1971d2895af135ba62eacd705be00ea4
-    md5: f450dddf8dd7f73240953bd1392fad0e
-work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19800101-19801231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/land/day/friver/gr/v20190429/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19800101-19801231.nc
-  hashes:
-    binhash: ff0ffd86feb884a2bb76558697b56210
-    md5: 276e2d7dfe9d12a43e8b9da3ce57d055
-work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19810101-19811231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/land/day/friver/gr/v20190429/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19810101-19811231.nc
-  hashes:
-    binhash: 3b6f5d2855411b2c11336221a0fa7bcf
-    md5: 51a09f658d14a92ed9ac9fb20b80a1f1
-work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19820101-19821231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/land/day/friver/gr/v20190429/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19820101-19821231.nc
-  hashes:
-    binhash: bd37d87654704a191d68547ff9b4fa2c
-    md5: ca4121eeac6dbfc1916f03bf78d946f4
-work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19830101-19831231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/land/day/friver/gr/v20190429/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19830101-19831231.nc
-  hashes:
-    binhash: 70e2253bffa9138943c6e6b503f63297
-    md5: 2d016b2147eecf1ca31ea881159b27d8
-work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19840101-19841231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/land/day/friver/gr/v20190429/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19840101-19841231.nc
-  hashes:
-    binhash: 653e12466fdc9bc1091e2945fcc68850
-    md5: 1905626b0d9cf2f0a227913c3fbd5aaf
-work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19850101-19851231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/land/day/friver/gr/v20190429/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19850101-19851231.nc
-  hashes:
-    binhash: 3978d5d9ec91f3301ed9906fa40a376e
-    md5: 6620b96409a7af6f38d0d61d7ef0b5c1
-work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19860101-19861231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/land/day/friver/gr/v20190429/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19860101-19861231.nc
-  hashes:
-    binhash: 1ba43ecf0387fd714a55c361aec150a9
-    md5: 0dfc13fb62d8ff8330897efb5e8a3ca2
-work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19870101-19871231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/land/day/friver/gr/v20190429/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19870101-19871231.nc
-  hashes:
-    binhash: 367940e69d308a0eda2cd94b5435e4b8
-    md5: 31bc1cee6c3b4a9c48a2ebe3c0cfeb53
-work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19880101-19881231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/land/day/friver/gr/v20190429/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19880101-19881231.nc
-  hashes:
-    binhash: 1315879bf6221d651d47eca4633ba246
-    md5: b9fbe4c7eec2d496cdc80b4550597ac6
-work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19890101-19891231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/land/day/friver/gr/v20190429/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19890101-19891231.nc
-  hashes:
-    binhash: 779061a13e0d27d35caab7bbbdd91b9f
-    md5: 658786e1d803f9e3b2bd3fa6f5cf98b7
-work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19900101-19901231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/land/day/friver/gr/v20190429/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19900101-19901231.nc
-  hashes:
-    binhash: 57df0b4536307b51a39b53ddd2cbe10a
-    md5: fe07c98fad52f17bb377d625bc88c38c
-work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19910101-19911231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/land/day/friver/gr/v20190429/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19910101-19911231.nc
-  hashes:
-    binhash: ecc5e771ca63f8abfc2db635728cd733
-    md5: 4ce7e5b4821ee936c48bc1b7cb9898ef
-work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19920101-19921231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/land/day/friver/gr/v20190429/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19920101-19921231.nc
-  hashes:
-    binhash: be57cc09cc19fd12e30a97970a1884fd
-    md5: 87beeae8a3fe0c5fd6ef0b15608033a8
-work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19930101-19931231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/land/day/friver/gr/v20190429/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19930101-19931231.nc
-  hashes:
-    binhash: 78fc483f275a38939d74f6fb20a2eeca
-    md5: c93c3d18d0430a5067c597fa79d89e3d
-work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19940101-19941231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/land/day/friver/gr/v20190429/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19940101-19941231.nc
-  hashes:
-    binhash: 711197531a82ef307e8f06ca67a0a49b
-    md5: b344b5fcdc4307b7640973b0f3bb8cda
-work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19950101-19951231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/land/day/friver/gr/v20190429/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19950101-19951231.nc
-  hashes:
-    binhash: 53289f9112db54177ad06b0a8a566d1d
-    md5: e6adc896eb5dae51fef9bd3f986fe71b
-work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19960101-19961231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/land/day/friver/gr/v20190429/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19960101-19961231.nc
-  hashes:
-    binhash: 29a3119f237abbe5e6b72a3c3db76e43
-    md5: 98d40136ed8c7b3003196aa54e89f3ec
-work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19970101-19971231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/land/day/friver/gr/v20190429/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19970101-19971231.nc
-  hashes:
-    binhash: f52b0a1e86aed52789ed9d40819dd60b
-    md5: db75a5d69ab686335c4f4478c8d21f02
-work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19980101-19981231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/land/day/friver/gr/v20190429/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19980101-19981231.nc
-  hashes:
-    binhash: d70b9b224ea5178ebfe3c952b90eb6ed
-    md5: fb1a1672c248a739b0b0673f84a97366
-work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19990101-19991231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/land/day/friver/gr/v20190429/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19990101-19991231.nc
-  hashes:
-    binhash: d9031b9c38bf8f9faf24f6615710f8e3
-    md5: c9edb6611ac68e290087d34d700e3a79
-work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20000101-20001231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/land/day/friver/gr/v20190429/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20000101-20001231.nc
-  hashes:
-    binhash: ee2787806a5120fa22cec89014e7f5ba
-    md5: 0de80f1744cdd5f310d7bd3864ca9dc0
-work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20010101-20011231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/land/day/friver/gr/v20190429/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20010101-20011231.nc
-  hashes:
-    binhash: c1abd600b97ac4b6513643de8a293f49
-    md5: f150238371a844142611df01eee3ca19
-work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20020101-20021231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/land/day/friver/gr/v20190429/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20020101-20021231.nc
-  hashes:
-    binhash: eb7f732799cdef9bda8d59882ba0bd44
-    md5: bb2af90fe9e0c9c4b839226c6b2cdd5e
-work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20030101-20031231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/land/day/friver/gr/v20190429/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20030101-20031231.nc
-  hashes:
-    binhash: 8402de3d8960ba9e522dbd024c7a4169
-    md5: 32047c99e0cd10d281917b883fe9d601
-work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20040101-20041231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/land/day/friver/gr/v20190429/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20040101-20041231.nc
-  hashes:
-    binhash: 59eaa024c918ea604fd92c7b23a52a39
-    md5: 77db35c5be0aedb86aaaba1e426e6ae4
-work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20050101-20051231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/land/day/friver/gr/v20190429/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20050101-20051231.nc
-  hashes:
-    binhash: 740b902758710e357c5c7dc6aeaa6a0a
-    md5: f83c449fd30e62255974b29376ade9cd
-work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20060101-20061231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/land/day/friver/gr/v20190429/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20060101-20061231.nc
-  hashes:
-    binhash: 913956d0c0064d7e9ae3368e9a4694b4
-    md5: fb9410439b9e02ff1e143661913e709c
-work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20070101-20071231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/land/day/friver/gr/v20190429/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20070101-20071231.nc
-  hashes:
-    binhash: af7199645e5a05a6e73db849a59e3b6a
-    md5: 73ecb39aa802b3334eb3676fd79601f2
-work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20080101-20081231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/land/day/friver/gr/v20190429/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20080101-20081231.nc
-  hashes:
-    binhash: 47b6b1cc34303007e19364d3039acdaf
-    md5: 873ca6c1c7df1845d265bb1f7c1dbcf0
-work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20090101-20091231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/land/day/friver/gr/v20190429/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20090101-20091231.nc
-  hashes:
-    binhash: 596457a1073e0986ced5d8a0fe10cd78
-    md5: 3cec211b469e4561708bf095f7d48b18
-work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20100101-20101231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/land/day/friver/gr/v20190429/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20100101-20101231.nc
-  hashes:
-    binhash: ac709624824a7cfcdf04a13719aed863
-    md5: 7dff12fe76c35dcd483d07a117ba76bf
-work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20110101-20111231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/land/day/friver/gr/v20190429/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20110101-20111231.nc
-  hashes:
-    binhash: 787f3fe17c687c4a833e348c20ef2ab6
-    md5: 7f0005094ec92cf8b2c3c789bc4eff36
-work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20120101-20121231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/land/day/friver/gr/v20190429/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20120101-20121231.nc
-  hashes:
-    binhash: 49e53a7b2da15c1e47c0f116e84c2de2
-    md5: 30f7704577460cdf55146beecb7da790
-work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20130101-20131231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/land/day/friver/gr/v20190429/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20130101-20131231.nc
-  hashes:
-    binhash: 89eaac6afe2de7677ce3d8238d140df3
-    md5: e537b381f9ab5251fbb77b66ee300e97
-work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20140101-20141231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/land/day/friver/gr/v20190429/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20140101-20141231.nc
-  hashes:
-    binhash: 0cb62b25af58b36bfc9b8d56e8a20b3c
-    md5: 02c8f0c62314c962d3a667b95039e9fc
-work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20150101-20151231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/land/day/friver/gr/v20190429/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20150101-20151231.nc
-  hashes:
-    binhash: a968de3761f7759ef26bb26ac5499ca5
-    md5: b5f3690d69904531a4881baba1339463
-work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20160101-20161231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/land/day/friver/gr/v20190429/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20160101-20161231.nc
-  hashes:
-    binhash: c7e9da079456839da764bbcb8a54fe47
-    md5: f47f7b5a75da2baf6783bd2577bb4c97
-work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20170101-20171231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/land/day/friver/gr/v20190429/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20170101-20171231.nc
-  hashes:
-    binhash: 4ad8c0494fbe185353c0ac27bb632803
-    md5: 32805c79aca5e6ae4fe863377f886d7f
-work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20180101-20181231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/land/day/friver/gr/v20190429/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20180101-20181231.nc
-  hashes:
-    binhash: 9e48e62738ed171424a9affd1a33de04
-    md5: f97dfa5400b0c2dc8bd45a33168cc2a6
-work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20190101-20190105.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/land/day/friver/gr/v20190429/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20190101-20190105.nc
-  hashes:
-    binhash: 36d7f4b4cd4d038da099b444d984d0b0
-    md5: 8cdb2421fa7056bc3c07577005071f71
-work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_195801010000-195812312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/huss/gr/v20190429/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_195801010000-195812312100.nc
-  hashes:
-    binhash: 2782e19a9b81a4ff517847c0b19d0144
-    md5: 3392450cebbfa3e668a020869842d959
-work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_195901010000-195912312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/huss/gr/v20190429/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_195901010000-195912312100.nc
-  hashes:
-    binhash: 11954c54b8e7c7635533812a380b5db0
-    md5: 5d0a0a96bb61aa1871e3ecb74fca1fca
-work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196001010000-196012312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/huss/gr/v20190429/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196001010000-196012312100.nc
-  hashes:
-    binhash: b888ebb2d9d612280cf74994c715d159
-    md5: 432065b6b0bfa84b9484de934478638b
-work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196101010000-196112312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/huss/gr/v20190429/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196101010000-196112312100.nc
-  hashes:
-    binhash: 7bda1bdc3fe8e622b852dde3238753e1
-    md5: d4349173cafde8bc4d56e7163984de01
-work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196201010000-196212312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/huss/gr/v20190429/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196201010000-196212312100.nc
-  hashes:
-    binhash: 914b31fb363d678a8137524856576a88
-    md5: 8d4e24c637d6fdd0cfabb2ea4ed046fe
-work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196301010000-196312312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/huss/gr/v20190429/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196301010000-196312312100.nc
-  hashes:
-    binhash: 1574c40f00a8ef6c13489bdd79fd7337
-    md5: 14cd75e109b268ef5fd5d93c11fd9db9
-work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196401010000-196412312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/huss/gr/v20190429/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196401010000-196412312100.nc
-  hashes:
-    binhash: 829dd4f34a3fd233676ad637d6a79606
-    md5: 6a47d386ba98fadbe17ec90176c1cc31
-work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196501010000-196512312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/huss/gr/v20190429/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196501010000-196512312100.nc
-  hashes:
-    binhash: 861dead7f5a539242de290aaa1749cca
-    md5: fad999a125783635bcddbdc433220801
-work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196601010000-196612312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/huss/gr/v20190429/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196601010000-196612312100.nc
-  hashes:
-    binhash: 1e09e2e6f21461a7bd319a19517b02ce
-    md5: 06331818a2a9eec3d744c6cc1640c887
-work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196701010000-196712312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/huss/gr/v20190429/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196701010000-196712312100.nc
-  hashes:
-    binhash: e0eab02a1b8d00ee4e871c68f245ec3a
-    md5: 8226c7e42db42e766619706bcf8d772c
-work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196801010000-196812312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/huss/gr/v20190429/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196801010000-196812312100.nc
-  hashes:
-    binhash: 611201ba5d16bb900f4aa1439238cb49
-    md5: cec41bbe965e4a2592248c33c3da7651
-work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196901010000-196912312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/huss/gr/v20190429/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196901010000-196912312100.nc
-  hashes:
-    binhash: e5d7bf499db9b4d5534ae2427f7df22b
-    md5: 327b1eed77221ef0fe833c28aa05dc76
-work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197001010000-197012312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/huss/gr/v20190429/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197001010000-197012312100.nc
-  hashes:
-    binhash: 72b3d82a9b35df57bf4f373c8b72eb90
-    md5: 9737cabf0db1410ebabf1fdd72c58681
-work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197101010000-197112312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/huss/gr/v20190429/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197101010000-197112312100.nc
-  hashes:
-    binhash: 888c1ce34baa450dfa2c94e0b143d0f0
-    md5: bf7d73dc00217cae88e90630d9157012
-work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197201010000-197212312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/huss/gr/v20190429/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197201010000-197212312100.nc
-  hashes:
-    binhash: 2ca41add6b0e696dff7865b14c56c298
-    md5: fab9a9813ff0043f18a47f33946e6d58
-work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197301010000-197312312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/huss/gr/v20190429/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197301010000-197312312100.nc
-  hashes:
-    binhash: 3736883af0b99a7840563a724eef66a2
-    md5: 57c646d56dd1597db17a82edc5264dd7
-work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197401010000-197412312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/huss/gr/v20190429/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197401010000-197412312100.nc
-  hashes:
-    binhash: 9eeb33d9ea2218760336842387339c6a
-    md5: d2cd179b4907dd420776441c60a0b318
-work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197501010000-197512312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/huss/gr/v20190429/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197501010000-197512312100.nc
-  hashes:
-    binhash: f9197052a9a5878705d2e73442a6897b
-    md5: ad77df4c881ba8b735b4717a8be06a50
-work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197601010000-197612312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/huss/gr/v20190429/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197601010000-197612312100.nc
-  hashes:
-    binhash: d7126fa6407f8896858d21529ec5113d
-    md5: cc899996b3fed7b3d7f24fdb0ca37e14
-work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197701010000-197712312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/huss/gr/v20190429/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197701010000-197712312100.nc
-  hashes:
-    binhash: 24e22f5575ccdfe6ff460a804f381cde
-    md5: 3d626733f1d78cbdcba7e39ce58c44cd
-work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197801010000-197812312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/huss/gr/v20190429/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197801010000-197812312100.nc
-  hashes:
-    binhash: 5d9de5d728d4677d3a86fa08e03bfb1c
-    md5: 04cbc4d0aa7945493c743c8a58926731
-work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197901010000-197912312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/huss/gr/v20190429/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197901010000-197912312100.nc
-  hashes:
-    binhash: 7869a76c3f76b879337478f9cd1fe456
-    md5: 461d431b5aa5fb12ecba4a9c5f838333
-work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198001010000-198012312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/huss/gr/v20190429/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198001010000-198012312100.nc
-  hashes:
-    binhash: 5fc4e8c237a244be092144a878db5d67
-    md5: ad3089eb53f182b5770e9ea3ef06c2ed
-work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198101010000-198112312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/huss/gr/v20190429/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198101010000-198112312100.nc
-  hashes:
-    binhash: 15158a6e619cb3d2417cc3671a1d2538
-    md5: b1e6506a35510c80a45ea281ecc1bff6
-work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198201010000-198212312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/huss/gr/v20190429/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198201010000-198212312100.nc
-  hashes:
-    binhash: 06a9be275c4dd02ca5e18512cb342851
-    md5: 46cce6585647138107f6b456952fb542
-work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198301010000-198312312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/huss/gr/v20190429/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198301010000-198312312100.nc
-  hashes:
-    binhash: 84c4923f1b1bafa1f5f4529ebe071aed
-    md5: 4183acca2a28192a25297f0db5d2c35a
-work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198401010000-198412312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/huss/gr/v20190429/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198401010000-198412312100.nc
-  hashes:
-    binhash: 0a6fd3df98a8ab4fb9e7252e1b1ea32f
-    md5: 9c2549dbd745d775286455053ac1e8ab
-work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198501010000-198512312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/huss/gr/v20190429/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198501010000-198512312100.nc
-  hashes:
-    binhash: dd03c8b456bd7cf74ac8668f7812106f
-    md5: 32cce7c48884a339ed506605795b5fa8
-work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198601010000-198612312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/huss/gr/v20190429/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198601010000-198612312100.nc
-  hashes:
-    binhash: c39ac8fcabf986cf3f434baf8653006e
-    md5: 5db7cebf3fdb857415a30b9067fa9857
-work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198701010000-198712312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/huss/gr/v20190429/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198701010000-198712312100.nc
-  hashes:
-    binhash: 1e7c861b26cca78ac1428c1d7a63aecd
-    md5: e67b8be77465f1f2ecd28643bb15814e
-work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198801010000-198812312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/huss/gr/v20190429/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198801010000-198812312100.nc
-  hashes:
-    binhash: c8728809528a5419e04d02b17cda58d6
-    md5: d65b4154dc2c6a0ffcad1a0d213b4449
-work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198901010000-198912312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/huss/gr/v20190429/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198901010000-198912312100.nc
-  hashes:
-    binhash: c44c06061e0959e548b31200210a13e3
-    md5: 1768c0299bbfb47d28f722beb55817fb
-work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199001010000-199012312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/huss/gr/v20190429/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199001010000-199012312100.nc
-  hashes:
-    binhash: 8e40816948da85ebdfd45fd278aa0a56
-    md5: 26971fa56830a9478c005fe872168d96
-work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199101010000-199112312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/huss/gr/v20190429/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199101010000-199112312100.nc
-  hashes:
-    binhash: 945b5dc3be1669a495f202676c13cc94
-    md5: ca774ab90645ae758242344aa2ceda51
-work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199201010000-199212312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/huss/gr/v20190429/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199201010000-199212312100.nc
-  hashes:
-    binhash: 25898ed771941705e9e39fef3b1526e2
-    md5: aec5684fa40064770990aa4cf59196c6
-work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199301010000-199312312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/huss/gr/v20190429/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199301010000-199312312100.nc
-  hashes:
-    binhash: b269e990195b26fd858af3bf75e57aaf
-    md5: ef8f54fd29957c2f46a74299cd5d0d3e
-work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199401010000-199412312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/huss/gr/v20190429/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199401010000-199412312100.nc
-  hashes:
-    binhash: c0d1e4eb2fc34f2b8a8fa4321fe069f8
-    md5: a19c141d7fdecabee042c61b95a3261a
-work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199501010000-199512312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/huss/gr/v20190429/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199501010000-199512312100.nc
-  hashes:
-    binhash: 9535bf64441bf5f5381b1f3a4773ff7e
-    md5: 898bd88c52e52683e39cf46aaf630a44
-work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199601010000-199612312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/huss/gr/v20190429/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199601010000-199612312100.nc
-  hashes:
-    binhash: 29de31897ad6fbfd98ee7bfef31c0e8c
-    md5: 3367fd683728470f14d901965eacc9d2
-work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199701010000-199712312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/huss/gr/v20190429/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199701010000-199712312100.nc
-  hashes:
-    binhash: afeb7dac9c8721619d3cfd7b8409f8f3
-    md5: 3dee8e9b4f979cda4b3293291bf7a19e
-work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199801010000-199812312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/huss/gr/v20190429/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199801010000-199812312100.nc
-  hashes:
-    binhash: 658b2befc7bb5b2079c1c2e5840086ba
-    md5: 414505ed32fec63780e5597cdaa84af2
-work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199901010000-199912312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/huss/gr/v20190429/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199901010000-199912312100.nc
-  hashes:
-    binhash: 0881af5b4355aa9e8e641c1dfa41d917
-    md5: 6a871bd643066c75098d1bfd8e2be516
-work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200001010000-200012312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/huss/gr/v20190429/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200001010000-200012312100.nc
-  hashes:
-    binhash: e9d4ec541895c3ef3d75ca002cd7cb87
-    md5: e6f5a2d464e7e8d42c38872bec747e43
-work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200101010000-200112312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/huss/gr/v20190429/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200101010000-200112312100.nc
-  hashes:
-    binhash: 63860b47f0c39412987e1dd6c4e6d3ea
-    md5: 70ba42c7ddd063effece0f1c538cc4d3
-work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200201010000-200212312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/huss/gr/v20190429/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200201010000-200212312100.nc
-  hashes:
-    binhash: 4fa881b0ed072979c78100ad0bb0cea3
-    md5: 69db71473a4f95e190dfad5a6c752aba
-work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200301010000-200312312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/huss/gr/v20190429/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200301010000-200312312100.nc
-  hashes:
-    binhash: 3daf7812e1788179e9eb25632a58bb9e
-    md5: 3f26996943804f7baaa4812f4b120698
-work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200401010000-200412312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/huss/gr/v20190429/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200401010000-200412312100.nc
-  hashes:
-    binhash: a8dd97639e2294a04f1bd247550688c6
-    md5: d726065095779627eb3c0999bd72bf6a
-work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200501010000-200512312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/huss/gr/v20190429/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200501010000-200512312100.nc
-  hashes:
-    binhash: dea37e9a18f96acc6ced0b75f9eccdae
-    md5: 1de177eeac382af04a75e8bac83bc22a
-work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200601010000-200612312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/huss/gr/v20190429/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200601010000-200612312100.nc
-  hashes:
-    binhash: aae0053c0a608997ffde6ab9c5fb794f
-    md5: ae038af132a7f93a01fac1de4555138e
-work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200701010000-200712312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/huss/gr/v20190429/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200701010000-200712312100.nc
-  hashes:
-    binhash: 634b68539db549de57b63b2a8dbd2d87
-    md5: d08aef1d4156caf1cd7a2e2b4f553adb
-work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200801010000-200812312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/huss/gr/v20190429/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200801010000-200812312100.nc
-  hashes:
-    binhash: 0967695625d41a74d78f7803b8debfff
-    md5: c00270a0e507cda1ce37a8efa888abd2
-work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200901010000-200912312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/huss/gr/v20190429/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200901010000-200912312100.nc
-  hashes:
-    binhash: 0503497305e121a152ddd5be59bda2e7
-    md5: 7f9517e87f0eb0f608d530ee6f90ee07
-work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201001010000-201012312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/huss/gr/v20190429/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201001010000-201012312100.nc
-  hashes:
-    binhash: f7121f336dc86b321037dd233dbdafb1
-    md5: bea1c282bac9e7924935f48110d3619f
-work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201101010000-201112312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/huss/gr/v20190429/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201101010000-201112312100.nc
-  hashes:
-    binhash: d08be7dc6aca3d3c14916f1f85a649cf
-    md5: 746fbce38ffadeb4f77554a2d5f22d85
-work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201201010000-201212312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/huss/gr/v20190429/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201201010000-201212312100.nc
-  hashes:
-    binhash: e690424788ca422d2cfab50c7e4bc9dd
-    md5: ff0b672e193dde85c442a869060fb142
-work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201301010000-201312312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/huss/gr/v20190429/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201301010000-201312312100.nc
-  hashes:
-    binhash: a0c25984f7cb8a4f1d5ed6daae5f3733
-    md5: 07b448f73b90eb537f1eaa011c786ac0
-work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201401010000-201412312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/huss/gr/v20190429/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201401010000-201412312100.nc
-  hashes:
-    binhash: db01fd35a7a3afd084c775f84a2c1f8d
-    md5: 9b0fe715d29cfe695fc8b66a9330d8b3
-work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201501010000-201512312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/huss/gr/v20190429/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201501010000-201512312100.nc
-  hashes:
-    binhash: eb733c786de0e84b1a73b6b96459ca2c
-    md5: 57597dd3790132b7b4eabd4a0e5d2500
-work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201601010000-201612312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/huss/gr/v20190429/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201601010000-201612312100.nc
-  hashes:
-    binhash: ce3893645da6ba75ca970f09e8c23255
-    md5: 90a2a0588708021658d28bd8d8d34b8e
-work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201701010000-201712312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/huss/gr/v20190429/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201701010000-201712312100.nc
-  hashes:
-    binhash: 89c94f3d946cdf2607a34ce5e9031b71
-    md5: eb38a728fecfc4364c5e63412e5095ce
-work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201801010000-201812312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/huss/gr/v20190429/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201801010000-201812312100.nc
-  hashes:
-    binhash: 96b0ac11f1acf93fe5a9bc6fb6e6f945
-    md5: eef8f3a6ef9364558377b1642e6aceae
-work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201901010000-201901052100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/huss/gr/v20190429/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201901010000-201901052100.nc
-  hashes:
-    binhash: 852422f81fbea1c08b8c79d06ae62405
-    md5: 7deb92fb03895597f00b4b71c8fd1e19
-work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19580101-19581231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/landIce/day/licalvf/gr/v20190429/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19580101-19581231.nc
-  hashes:
-    binhash: f71ed73eab8a7dec6abf3e97e939877d
-    md5: 949e36fe8ce03610ca401a38f6ba4571
-work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19590101-19591231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/landIce/day/licalvf/gr/v20190429/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19590101-19591231.nc
-  hashes:
-    binhash: 6d608b1f71abd6e17c73dd53fe75c249
-    md5: a17753426cc026ce9c1bf91e191a9e0f
-work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19600101-19601231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/landIce/day/licalvf/gr/v20190429/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19600101-19601231.nc
-  hashes:
-    binhash: b89e94768b2aa2e935c1f415abae61cd
-    md5: 47741b26140296b5fe1dcf8da93f92ca
-work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19610101-19611231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/landIce/day/licalvf/gr/v20190429/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19610101-19611231.nc
-  hashes:
-    binhash: f20bb69324c9546646ac7de3b431f2e3
-    md5: ac76e825daba89e4f93dba91ff9d60ed
-work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19620101-19621231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/landIce/day/licalvf/gr/v20190429/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19620101-19621231.nc
-  hashes:
-    binhash: cf04bca7770755642f24031df29f3f81
-    md5: a1ffd2bf855c3f0df7965135813fd2f4
-work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19630101-19631231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/landIce/day/licalvf/gr/v20190429/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19630101-19631231.nc
-  hashes:
-    binhash: 7e56c31e3567af636d725eb617362c89
-    md5: 7b347dfea0753116d6db02155b13507d
-work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19640101-19641231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/landIce/day/licalvf/gr/v20190429/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19640101-19641231.nc
-  hashes:
-    binhash: d8de064364ed50a3d01cb87d4dfc3a72
-    md5: 860504ebafc61dc9a64aa49b23a46a3b
-work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19650101-19651231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/landIce/day/licalvf/gr/v20190429/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19650101-19651231.nc
-  hashes:
-    binhash: 0a65f65d3d7aa8fc241b4afd61f5a10f
-    md5: 5429415bcafeac17993e4a76b1b3311b
-work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19660101-19661231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/landIce/day/licalvf/gr/v20190429/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19660101-19661231.nc
-  hashes:
-    binhash: 9488848d7b36eaaab9ef666ac699f2a2
-    md5: 4d8c0b1e7fbf01e24d9c8a9854b46aaf
-work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19670101-19671231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/landIce/day/licalvf/gr/v20190429/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19670101-19671231.nc
-  hashes:
-    binhash: ebfe2250bdc339f051f1f02afd1e7341
-    md5: bb9f6108ccdb67314f7e2ac37ea2f4b2
-work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19680101-19681231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/landIce/day/licalvf/gr/v20190429/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19680101-19681231.nc
-  hashes:
-    binhash: 12d240057dd2846571060e99b7a8f21b
-    md5: 0cab9be688b7878785b10cb7364abdbe
-work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19690101-19691231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/landIce/day/licalvf/gr/v20190429/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19690101-19691231.nc
-  hashes:
-    binhash: 0d07199282ee717d709713832397ce83
-    md5: 88cf7d0e26102a9cb8600024302e385d
-work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19700101-19701231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/landIce/day/licalvf/gr/v20190429/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19700101-19701231.nc
-  hashes:
-    binhash: 863f980f7b587e6772de74a347ba4793
-    md5: e409251eefb35e48c2bc7541ed9e7ec1
-work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19710101-19711231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/landIce/day/licalvf/gr/v20190429/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19710101-19711231.nc
-  hashes:
-    binhash: 08a3c6b80a8e2ce3dae29795cbce0331
-    md5: 197f85474a2d81af84ce62fbe3c5bbba
-work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19720101-19721231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/landIce/day/licalvf/gr/v20190429/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19720101-19721231.nc
-  hashes:
-    binhash: 5c4cfbee6ef86f91fd57be96f0d47f77
-    md5: 7c4d7a1afb735f522c0e6a0d59d3a685
-work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19730101-19731231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/landIce/day/licalvf/gr/v20190429/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19730101-19731231.nc
-  hashes:
-    binhash: 0f730d3bd07dd77f61200ccce8a66430
-    md5: 312e1965ef96bc2961f992e69cf2d3b7
-work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19740101-19741231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/landIce/day/licalvf/gr/v20190429/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19740101-19741231.nc
-  hashes:
-    binhash: 784f4a478b60d5649ff22407b1f01569
-    md5: fb2f9a522749e8c65f88a42e94dcd9f3
-work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19750101-19751231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/landIce/day/licalvf/gr/v20190429/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19750101-19751231.nc
-  hashes:
-    binhash: ffffb2350aa3e5f105c9072a53badbd8
-    md5: 23041f66d50f68dd808b7a255948796b
-work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19760101-19761231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/landIce/day/licalvf/gr/v20190429/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19760101-19761231.nc
-  hashes:
-    binhash: bc7bbd0282803614970146ebbced3f14
-    md5: bd483ce5f090dd03174a55057b327630
-work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19770101-19771231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/landIce/day/licalvf/gr/v20190429/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19770101-19771231.nc
-  hashes:
-    binhash: 1f202af08656601dd9ae0fce5dc64f27
-    md5: b9439812ca68f3c3821bd46e926caf9c
-work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19780101-19781231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/landIce/day/licalvf/gr/v20190429/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19780101-19781231.nc
-  hashes:
-    binhash: 2a7a7be05cfe133fa0bffda66d0f51e1
-    md5: 3604517b540d066f59d04cf3695e65a3
-work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19790101-19791231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/landIce/day/licalvf/gr/v20190429/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19790101-19791231.nc
-  hashes:
-    binhash: bba7804cf7d4fecd471e51437e2a9eb9
-    md5: d24347a1495b5917bd1ca3f175d3c541
-work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19800101-19801231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/landIce/day/licalvf/gr/v20190429/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19800101-19801231.nc
-  hashes:
-    binhash: 2ee58a9ab4b222846eb7234d73fc672c
-    md5: f6a5902189c17c9ed3c47c0afdf335fb
-work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19810101-19811231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/landIce/day/licalvf/gr/v20190429/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19810101-19811231.nc
-  hashes:
-    binhash: b104899413966bfe3c531502c17ea418
-    md5: d236b39422557286bfd8be80fbe557e8
-work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19820101-19821231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/landIce/day/licalvf/gr/v20190429/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19820101-19821231.nc
-  hashes:
-    binhash: e61e5229a9f84cf51de8b527fc2f8e9d
-    md5: dbf55285a711f5e8ff0e7c9b0fd8d54c
-work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19830101-19831231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/landIce/day/licalvf/gr/v20190429/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19830101-19831231.nc
-  hashes:
-    binhash: 8610c6fd335c02bf94aeb880a2f29029
-    md5: 9b2f763f0e65558e5dc884cf1b717c3d
-work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19840101-19841231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/landIce/day/licalvf/gr/v20190429/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19840101-19841231.nc
-  hashes:
-    binhash: b493e4061674ba4e8190ad8bb451ba72
-    md5: 106b694b2645eef1e9495573b65deae3
-work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19850101-19851231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/landIce/day/licalvf/gr/v20190429/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19850101-19851231.nc
-  hashes:
-    binhash: 866dc42ccfd7d83fa55d7389d4834fe5
-    md5: 12315304cc5ef5c13c8464289622f5c9
-work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19860101-19861231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/landIce/day/licalvf/gr/v20190429/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19860101-19861231.nc
-  hashes:
-    binhash: 432d66acfe9de1532ddb99385c964800
-    md5: 81aa4ddf1417bbc5674fced916b03781
-work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19870101-19871231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/landIce/day/licalvf/gr/v20190429/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19870101-19871231.nc
-  hashes:
-    binhash: f43a9834498ff7284e1670409f2268be
-    md5: d16e139f1ad55578ac91bae20c6f7e92
-work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19880101-19881231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/landIce/day/licalvf/gr/v20190429/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19880101-19881231.nc
-  hashes:
-    binhash: fa38e2f371e5e7549a75d5ad1de48296
-    md5: 13d3834795cd5fce365c72aae89a6d13
-work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19890101-19891231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/landIce/day/licalvf/gr/v20190429/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19890101-19891231.nc
-  hashes:
-    binhash: 4eb3ac7a21f03aeaf09053afcb5316e4
-    md5: 7332b5d18beb2c8feaf66f069dc01766
-work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19900101-19901231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/landIce/day/licalvf/gr/v20190429/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19900101-19901231.nc
-  hashes:
-    binhash: aa4e90118292ba852fa515729bf6b199
-    md5: 535b359e5377a98879293fe461bd806b
-work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19910101-19911231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/landIce/day/licalvf/gr/v20190429/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19910101-19911231.nc
-  hashes:
-    binhash: 06be663a8671c13e629d574e7a148cb9
-    md5: 75056eece2176240a5d007da98712df6
-work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19920101-19921231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/landIce/day/licalvf/gr/v20190429/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19920101-19921231.nc
-  hashes:
-    binhash: da72f937bde903dd2adfc7e25f547407
-    md5: fc3f08bf7a7f6c53d881eabce6063d26
-work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19930101-19931231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/landIce/day/licalvf/gr/v20190429/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19930101-19931231.nc
-  hashes:
-    binhash: b7c65931e83b615ac9a0d4f7ece5ea51
-    md5: 8add64ca22e1653a46d3968ba121bba4
-work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19940101-19941231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/landIce/day/licalvf/gr/v20190429/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19940101-19941231.nc
-  hashes:
-    binhash: a9baf7cfb234f7cd4c07d5b08118ef54
-    md5: 6200f17023d79f6fa99ba477bc0dc03e
-work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19950101-19951231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/landIce/day/licalvf/gr/v20190429/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19950101-19951231.nc
-  hashes:
-    binhash: 3fb00cf6ff4cd9d03f2608643b848c5c
-    md5: 0da89ad062a69d5f06f590063d9519cf
-work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19960101-19961231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/landIce/day/licalvf/gr/v20190429/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19960101-19961231.nc
-  hashes:
-    binhash: 1f805e7e21c1326fedca189b18508995
-    md5: 2b073e70c44099322e030b505afb5d3b
-work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19970101-19971231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/landIce/day/licalvf/gr/v20190429/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19970101-19971231.nc
-  hashes:
-    binhash: ce002c9fb883eec214fffeb12c5dd99f
-    md5: cc18791c56aafb96de3d851b537563cd
-work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19980101-19981231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/landIce/day/licalvf/gr/v20190429/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19980101-19981231.nc
-  hashes:
-    binhash: bd71dbe0ee4abd1fe909cec59950e63b
-    md5: c2bf8d439ea68b8e838076a043a5afb1
-work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19990101-19991231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/landIce/day/licalvf/gr/v20190429/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_19990101-19991231.nc
-  hashes:
-    binhash: b3baff0ab164f246db16c84bf4f6a1bd
-    md5: 537cfa578e83acf9f351b0a730842954
-work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20000101-20001231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/landIce/day/licalvf/gr/v20190429/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20000101-20001231.nc
-  hashes:
-    binhash: ad031e00ae7453e9aa94c50202542cc5
-    md5: 28249df2d42df1e1d0673635214a6636
-work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20010101-20011231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/landIce/day/licalvf/gr/v20190429/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20010101-20011231.nc
-  hashes:
-    binhash: 0df754713311bdad984a4e183ea81e89
-    md5: 3cfb6ef3eab197c8165334b27ba948ea
-work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20020101-20021231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/landIce/day/licalvf/gr/v20190429/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20020101-20021231.nc
-  hashes:
-    binhash: e27ee5eafff3f8c4b6f243314be1cb86
-    md5: e3edf78535f42a7de5a82a68f8f18728
-work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20030101-20031231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/landIce/day/licalvf/gr/v20190429/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20030101-20031231.nc
-  hashes:
-    binhash: 55b445fdb18445dd0a18698d99701f6d
-    md5: 4b926a3c0b37bb255260fd8c163adddc
-work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20040101-20041231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/landIce/day/licalvf/gr/v20190429/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20040101-20041231.nc
-  hashes:
-    binhash: 6a2c182ca73b0d3bacb14e30ae21bd6c
-    md5: b4feeb55989e941f11f3ba105f1856ef
-work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20050101-20051231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/landIce/day/licalvf/gr/v20190429/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20050101-20051231.nc
-  hashes:
-    binhash: 318f2a4521e4e679451c520255d3f367
-    md5: 7f5ea8342a4d52bf23bdd8f3ff649a53
-work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20060101-20061231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/landIce/day/licalvf/gr/v20190429/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20060101-20061231.nc
-  hashes:
-    binhash: 38cb4c78cf73abc97ce0492ecc499a48
-    md5: 2177257f79e83cf87ca7711e526e16bb
-work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20070101-20071231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/landIce/day/licalvf/gr/v20190429/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20070101-20071231.nc
-  hashes:
-    binhash: c45ee38ae1e56d358fb921fc8be1dbed
-    md5: e787d5b90fab620168fe89aacff8df26
-work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20080101-20081231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/landIce/day/licalvf/gr/v20190429/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20080101-20081231.nc
-  hashes:
-    binhash: 0a60d9e38ec010fe8ba6b7a66c5f2174
-    md5: a66ae80dc86c91fa474ed3ac2200b756
-work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20090101-20091231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/landIce/day/licalvf/gr/v20190429/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20090101-20091231.nc
-  hashes:
-    binhash: 3a3a6feab01d411b8376713b82ffc8fe
-    md5: 2993df42849c86658ab347e557a631dc
-work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20100101-20101231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/landIce/day/licalvf/gr/v20190429/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20100101-20101231.nc
-  hashes:
-    binhash: 5f78ade36e35b6e91cf302bbe2cb2140
-    md5: c7b32a41c33c295679f35219a8bdfd04
-work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20110101-20111231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/landIce/day/licalvf/gr/v20190429/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20110101-20111231.nc
-  hashes:
-    binhash: 8956e3b5bb9c456f34ae2a63c11ce240
-    md5: b3503773f6ca53ed4dc8ce030afee29d
-work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20120101-20121231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/landIce/day/licalvf/gr/v20190429/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20120101-20121231.nc
-  hashes:
-    binhash: d2e5e7e3ecc9bcfe2d39fd5e447a5679
-    md5: e02ef5d2d60c9ecf30ce8b6e52a8194d
-work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20130101-20131231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/landIce/day/licalvf/gr/v20190429/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20130101-20131231.nc
-  hashes:
-    binhash: d30a0db245abbe4bf99a200b6b913ef4
-    md5: 79d5fd502ef94c9ee9cff298ebbb3b33
-work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20140101-20141231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/landIce/day/licalvf/gr/v20190429/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20140101-20141231.nc
-  hashes:
-    binhash: 1adcfa5ba3d774a5ad10f149db1c2553
-    md5: 376eb5643c7abb3bcd39c41269133fa5
-work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20150101-20151231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/landIce/day/licalvf/gr/v20190429/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20150101-20151231.nc
-  hashes:
-    binhash: 51e387f5b6dcb122c5408743396312bd
-    md5: 1b1e374608eafd02d3b5d35218258e3c
-work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20160101-20161231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/landIce/day/licalvf/gr/v20190429/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20160101-20161231.nc
-  hashes:
-    binhash: 063f4555fb3a0fb7083f5de99cd290df
-    md5: c3d1b0380de716d9b6ddc81b74569a18
-work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20170101-20171231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/landIce/day/licalvf/gr/v20190429/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20170101-20171231.nc
-  hashes:
-    binhash: d5cb64bcf7e7af3e7ce266a3ff54dae2
-    md5: 281c4e72a67e3233d28697cad1f12c27
-work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20180101-20181231.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/landIce/day/licalvf/gr/v20190429/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20180101-20181231.nc
-  hashes:
-    binhash: 910fc7e46ee76f5252cd8dd28aba6385
-    md5: ac1e116b5fa31000c51b629d882fb4ab
-work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20190101-20190105.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/landIce/day/licalvf/gr/v20190429/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_20190101-20190105.nc
-  hashes:
-    binhash: b695aa7c1603eec26fe93674bf2ccfe5
-    md5: 7d09d06ec59b71f0dffe288f7507b06d
-work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_195801010130-195812312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prra/gr/v20190429/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_195801010130-195812312230.nc
-  hashes:
-    binhash: f701d8a929e9d872e8e6a35e3a8e32ec
-    md5: 3f6f6aee303a519cb9f26e8fe24119e2
-work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_195901010130-195912312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prra/gr/v20190429/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_195901010130-195912312230.nc
-  hashes:
-    binhash: 14759e98444f39be594d5b9f0f32a911
-    md5: a9a4597ad0adaa89f198963ea90f34a9
-work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196001010130-196012312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prra/gr/v20190429/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196001010130-196012312230.nc
-  hashes:
-    binhash: 1701d31946ec375e31f28a5b7ed38aa2
-    md5: 7a2aa25a232774d8b646a8b5f1bf521c
-work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196101010130-196112312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prra/gr/v20190429/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196101010130-196112312230.nc
-  hashes:
-    binhash: 4b65154310676a09f80fc1b828dd665e
-    md5: a91756c6fe5df99fa9e1b61c2dbc1e04
-work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196201010130-196212312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prra/gr/v20190429/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196201010130-196212312230.nc
-  hashes:
-    binhash: 850629a9b2590c9c4ecf0a46ae9db257
-    md5: 0295ed6e67b4a8e6a6e347d98d1e7db5
-work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196301010130-196312312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prra/gr/v20190429/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196301010130-196312312230.nc
-  hashes:
-    binhash: 5e14ebe93ad746fdf7a3573dbba43f14
-    md5: e8a28b5429cd92a07ca118072abf58b9
-work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196401010130-196412312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prra/gr/v20190429/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196401010130-196412312230.nc
-  hashes:
-    binhash: b617e4ff5473d52209433b85d1e7c3cb
-    md5: 91c0346084acd33313d20a47e0a72437
-work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196501010130-196512312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prra/gr/v20190429/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196501010130-196512312230.nc
-  hashes:
-    binhash: cb793dcf5a236ecf9cbf4b2336d36a82
-    md5: 86f6d2e84bf943ecd62ca6f5400e0bee
-work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196601010130-196612312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prra/gr/v20190429/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196601010130-196612312230.nc
-  hashes:
-    binhash: 812cba7c7eafbb7ec8f11069fdec45bb
-    md5: af80d1310ad47af021df2ce21a2319ca
-work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196701010130-196712312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prra/gr/v20190429/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196701010130-196712312230.nc
-  hashes:
-    binhash: 849e08cc906f85bb8f73085bbcf8ae75
-    md5: 1f312898e87abf4fa63ff7a853e23f21
-work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196801010130-196812312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prra/gr/v20190429/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196801010130-196812312230.nc
-  hashes:
-    binhash: 3dafee65f1310fc87cd42a418f848ecb
-    md5: f2f1d827ed8ebe2a2c391cedfaca1c44
-work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196901010130-196912312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prra/gr/v20190429/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196901010130-196912312230.nc
-  hashes:
-    binhash: 72be3ddabd16803389e5008989c31f2c
-    md5: d18ec9969d69745e6aabc494c3192f36
-work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197001010130-197012312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prra/gr/v20190429/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197001010130-197012312230.nc
-  hashes:
-    binhash: 9e2d36865e2ad1861988a94bf59dbc95
-    md5: 902760ddd88c6b9a2fbd4102bd5d448a
-work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197101010130-197112312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prra/gr/v20190429/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197101010130-197112312230.nc
-  hashes:
-    binhash: 438e15ffebb6bcaf56f5188894718948
-    md5: 8b930738bad6cd631454369d15c578be
-work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197201010130-197212312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prra/gr/v20190429/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197201010130-197212312230.nc
-  hashes:
-    binhash: 80d1f094f1b10a5d98e0ddd463efb66e
-    md5: e7cb5a154c716677748fdb33892293ae
-work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197301010130-197312312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prra/gr/v20190429/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197301010130-197312312230.nc
-  hashes:
-    binhash: a0588af375dccd89d0e9612a096f1805
-    md5: abb00a05f8c9fd33af079b31a4f22a34
-work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197401010130-197412312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prra/gr/v20190429/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197401010130-197412312230.nc
-  hashes:
-    binhash: 58420e09bd80cb52a73397e2ed6865ca
-    md5: 3423f234b7906b10c0081e45dc733b92
-work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197501010130-197512312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prra/gr/v20190429/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197501010130-197512312230.nc
-  hashes:
-    binhash: 3790ee2a9aa6c3efc967b2ecc9ef066b
-    md5: ffb9aa9228fb596ec85a4e3e2c34075d
-work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197601010130-197612312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prra/gr/v20190429/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197601010130-197612312230.nc
-  hashes:
-    binhash: 2851842f4f7da1dea4c022e7cd33ebf8
-    md5: 2c829cfd0dcd5d8327e462752a29aa76
-work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197701010130-197712312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prra/gr/v20190429/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197701010130-197712312230.nc
-  hashes:
-    binhash: 0c91677931b57bfaf3a493508b6010f6
-    md5: 371b181c416171637d8df4bd2c539e4e
-work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197801010130-197812312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prra/gr/v20190429/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197801010130-197812312230.nc
-  hashes:
-    binhash: 415c0cef76caddfd9583159650531c4a
-    md5: 61f52580b47b3d54ad614b583f1c0fdc
-work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197901010130-197912312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prra/gr/v20190429/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197901010130-197912312230.nc
-  hashes:
-    binhash: 6fbf4d70b989f0d5e917992c5dc66e92
-    md5: 37bda0f852c24473c7bc5c581d0e0a6e
-work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198001010130-198012312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prra/gr/v20190429/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198001010130-198012312230.nc
-  hashes:
-    binhash: cc179f4ddbbf5e8230ab430e36d8b911
-    md5: a8e5985c9cc7d29e1f39fd28966a1086
-work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198101010130-198112312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prra/gr/v20190429/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198101010130-198112312230.nc
-  hashes:
-    binhash: afa4397461001e45225add5981fac73a
-    md5: 03f843f08d038e64d4fec64b61a8742c
-work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198201010130-198212312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prra/gr/v20190429/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198201010130-198212312230.nc
-  hashes:
-    binhash: 52e94de1e54ec773fcf53eee304b8f4b
-    md5: 481dd7dff70e0b007d93126de37e5189
-work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198301010130-198312312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prra/gr/v20190429/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198301010130-198312312230.nc
-  hashes:
-    binhash: 2cb222f313fa102b20a606f7caa28e27
-    md5: b92ab8b4d7bd75cab6d901fb11cca3cc
-work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198401010130-198412312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prra/gr/v20190429/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198401010130-198412312230.nc
-  hashes:
-    binhash: 14ffc9aa275a7dbc54f39c676ba15b05
-    md5: d8f23464ce2fca4728d1cfe1a73b6466
-work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198501010130-198512312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prra/gr/v20190429/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198501010130-198512312230.nc
-  hashes:
-    binhash: 50e04924a01b161db307ef7754c3d2aa
-    md5: 42352c141dda42ff9566251428dbf00b
-work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198601010130-198612312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prra/gr/v20190429/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198601010130-198612312230.nc
-  hashes:
-    binhash: 1f26f833f5d237a3ba53ca75be8f5dbb
-    md5: d8cc1a0670da8b5e46fae76390ea2963
-work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198701010130-198712312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prra/gr/v20190429/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198701010130-198712312230.nc
-  hashes:
-    binhash: 700c695af43edfa9a531e6b796954b81
-    md5: a1bd3d82b733b6a5d27033cba9bb165f
-work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198801010130-198812312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prra/gr/v20190429/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198801010130-198812312230.nc
-  hashes:
-    binhash: c5a040a0413c33aa9f56e8240f49e573
-    md5: bd2a5f918ce678a28eb31f9fbdbde0a1
-work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198901010130-198912312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prra/gr/v20190429/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198901010130-198912312230.nc
-  hashes:
-    binhash: 648928efeb98a452ea045ca47459fc62
-    md5: 140a14c584fd7a20966394a2b1c19cd6
-work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199001010130-199012312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prra/gr/v20190429/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199001010130-199012312230.nc
-  hashes:
-    binhash: 60773f412faac74405659393e09a9b65
-    md5: 345e7f89a92c43f0abaa8b4abb09c378
-work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199101010130-199112312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prra/gr/v20190429/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199101010130-199112312230.nc
-  hashes:
-    binhash: 0f2f9f2606cb54e90d39b7b28689de27
-    md5: 398d7f86905eaac94ae4ba62fa469998
-work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199201010130-199212312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prra/gr/v20190429/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199201010130-199212312230.nc
-  hashes:
-    binhash: b19228dfbd0628889c353f8c5f5788e2
-    md5: 2c4e9f884e015a586e0b393e56e49486
-work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199301010130-199312312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prra/gr/v20190429/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199301010130-199312312230.nc
-  hashes:
-    binhash: cf9dc6c99bc25642a88b551f609a31fb
-    md5: 7dcf4e7f8d75ef6faddb45b10c35e959
-work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199401010130-199412312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prra/gr/v20190429/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199401010130-199412312230.nc
-  hashes:
-    binhash: fbf9efa4aa45b44f1ccb8f004ee48c3a
-    md5: 25f1dcdb721957f0cdce086958eaafb8
-work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199501010130-199512312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prra/gr/v20190429/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199501010130-199512312230.nc
-  hashes:
-    binhash: 52b6c209aab52e169fe372b95610dae0
-    md5: 252822bdc5cee8246aa9ae1c1611156d
-work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199601010130-199612312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prra/gr/v20190429/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199601010130-199612312230.nc
-  hashes:
-    binhash: 6907d30d4b693f7109498dfbe4682bb5
-    md5: ab492e6589a1f48acbc478c49ea35106
-work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199701010130-199712312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prra/gr/v20190429/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199701010130-199712312230.nc
-  hashes:
-    binhash: cf7567986f91d83cab988f2cc543bae4
-    md5: edbed38335cb7252e9332ae73e38dc20
-work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199801010130-199812312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prra/gr/v20190429/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199801010130-199812312230.nc
-  hashes:
-    binhash: 663bd1ae2325fb84295e6575704ffa03
-    md5: a4062b75d3ef7af65778ea80ac411614
-work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199901010130-199912312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prra/gr/v20190429/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199901010130-199912312230.nc
-  hashes:
-    binhash: cedae1344d69e3fb79d9407846c96869
-    md5: 7562adc8e07682f9913e086d3989465f
-work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200001010130-200012312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prra/gr/v20190429/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200001010130-200012312230.nc
-  hashes:
-    binhash: 3d079a1225b2aa31368ac1d07ea4b06e
-    md5: d97425230a67abef3e4902115d041b50
-work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200101010130-200112312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prra/gr/v20190429/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200101010130-200112312230.nc
-  hashes:
-    binhash: 381bca07fc9649ef4beb8f02efcecf2e
-    md5: e5a34792fbef08db931d8156f9cba7aa
-work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200201010130-200212312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prra/gr/v20190429/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200201010130-200212312230.nc
-  hashes:
-    binhash: c3df2a0db97680e86e0f39488d6a707d
-    md5: 77f1fbba939f3c96e1635891562bfad4
-work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200301010130-200312312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prra/gr/v20190429/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200301010130-200312312230.nc
-  hashes:
-    binhash: d3302cdc433dc538a4dbc2715ddea18b
-    md5: f46e3f30b7e78ea731cd338f6e6754e8
-work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200401010130-200412312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prra/gr/v20190429/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200401010130-200412312230.nc
-  hashes:
-    binhash: b38c1a22d95c36caa64a4cf5b7aad412
-    md5: 0b4e8bd542de87d915ca39e687e8a76b
-work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200501010130-200512312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prra/gr/v20190429/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200501010130-200512312230.nc
-  hashes:
-    binhash: 96dbcd6e2158f11d8a146fe48c2fb18c
-    md5: b42d6540f6cb80328f548c4619fdda49
-work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200601010130-200612312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prra/gr/v20190429/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200601010130-200612312230.nc
-  hashes:
-    binhash: 1c27bf6c47f2938f918f1b9ff00d2242
-    md5: 0fc76ff32ec2202143c5d7d0899efd76
-work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200701010130-200712312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prra/gr/v20190429/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200701010130-200712312230.nc
-  hashes:
-    binhash: fbcec8b2210cc819af75b82453c175a8
-    md5: c7fe9075a3f7fb0f872d1a9308c913ae
-work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200801010130-200812312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prra/gr/v20190429/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200801010130-200812312230.nc
-  hashes:
-    binhash: 0571d6eeca45216e3ce7d8636dd28108
-    md5: 4e9f8b83bb1eaf5bfc2aebd4e87f75c2
-work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200901010130-200912312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prra/gr/v20190429/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200901010130-200912312230.nc
-  hashes:
-    binhash: cb8022bfb73fdf86ca601c999c885c0f
-    md5: 2ff4c12c32ec4c834d3d78e50511bf21
-work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201001010130-201012312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prra/gr/v20190429/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201001010130-201012312230.nc
-  hashes:
-    binhash: c56688cffae83fb1dad166c086a8bc4e
-    md5: 86a84337ad40021bf96b4c341fe20336
-work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201101010130-201112312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prra/gr/v20190429/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201101010130-201112312230.nc
-  hashes:
-    binhash: fe764e904f3214c05993ef1ad91d19cf
-    md5: a167cd4a6ecb170da5c5b73ad99bc0ab
-work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201201010130-201212312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prra/gr/v20190429/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201201010130-201212312230.nc
-  hashes:
-    binhash: d47b831eeee082ff172870ca07760e44
-    md5: 9174befbef5387e24adb2dea08baaf5c
-work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201301010130-201312312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prra/gr/v20190429/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201301010130-201312312230.nc
-  hashes:
-    binhash: 99ea3646a7eb892aaab3044f7be58916
-    md5: 434ee3d9640559e7af1c730207042874
-work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201401010130-201412312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prra/gr/v20190429/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201401010130-201412312230.nc
-  hashes:
-    binhash: 546e899a61f87b66c00a81c17611cfd4
-    md5: 9aa9807e6fa5b3e477ed67481d951c7d
-work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201501010130-201512312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prra/gr/v20190429/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201501010130-201512312230.nc
-  hashes:
-    binhash: 59da05c3481e985de456f74bb5654d01
-    md5: b5ae200e69a5adfa0e1ec53faa67eed7
-work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201601010130-201612312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prra/gr/v20190429/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201601010130-201612312230.nc
-  hashes:
-    binhash: 655e4cfa898749910b200911f9604772
-    md5: d5b518b55e78e4f9d2b712fde5d9137f
-work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201701010130-201712312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prra/gr/v20190429/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201701010130-201712312230.nc
-  hashes:
-    binhash: 2a66d533d1c2eb915a52f61566f62d50
-    md5: f712885f975345c132bef19e7b442b73
-work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201801010130-201812312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prra/gr/v20190429/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201801010130-201812312230.nc
-  hashes:
-    binhash: b02e9ede281a1f05655f09571783f525
-    md5: a4804209ea08bad0bfe9684ebc4f117f
-work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201901010130-201901052230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prra/gr/v20190429/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201901010130-201901052230.nc
-  hashes:
-    binhash: 7ea21535591398f3db11042de15d7998
-    md5: 785d43f30f818269662474b27eace1f0
-work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_195801010130-195812312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prsn/gr/v20190429/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_195801010130-195812312230.nc
-  hashes:
-    binhash: bab117ad0617cc882282b15fa90da109
-    md5: 54bfd60c31fb5607937ea4bc6121c24a
-work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_195901010130-195912312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prsn/gr/v20190429/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_195901010130-195912312230.nc
-  hashes:
-    binhash: 3e2c0123eccc325518cdd62fd84e1a7c
-    md5: 6df9e38fb96b876264f1161163187abc
-work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196001010130-196012312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prsn/gr/v20190429/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196001010130-196012312230.nc
-  hashes:
-    binhash: 04a2454f79633d494ba9e3286dfdd2b5
-    md5: f96ec58ea350cfe148f04faf6a61ce9d
-work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196101010130-196112312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prsn/gr/v20190429/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196101010130-196112312230.nc
-  hashes:
-    binhash: 7d27d456f55b5b88f87d5cfa9453fb98
-    md5: 1c4901809275164f84b2452cd6a10221
-work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196201010130-196212312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prsn/gr/v20190429/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196201010130-196212312230.nc
-  hashes:
-    binhash: 6a10809c88da81bde792c7aabdb6b28b
-    md5: 49f34b40be3f372bfe7b3cbc5e80fb83
-work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196301010130-196312312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prsn/gr/v20190429/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196301010130-196312312230.nc
-  hashes:
-    binhash: a334eeb208baa37d7aa02ed7a700fca3
-    md5: 700657464ed28bedc6b023d66c9a6c73
-work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196401010130-196412312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prsn/gr/v20190429/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196401010130-196412312230.nc
-  hashes:
-    binhash: 61125bd94975ec14f0260b6669a2b269
-    md5: 707b63527d1038e1928f8b8fde952031
-work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196501010130-196512312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prsn/gr/v20190429/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196501010130-196512312230.nc
-  hashes:
-    binhash: 41c82b995d75af7ad5007f455ef65e53
-    md5: 5787b6fd1aafbc1f57dd89f0e455d5ca
-work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196601010130-196612312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prsn/gr/v20190429/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196601010130-196612312230.nc
-  hashes:
-    binhash: 8532c804f05c71d77cea2177330af8ab
-    md5: c978849e7f471b1ce9bfcc2759c75cc5
-work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196701010130-196712312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prsn/gr/v20190429/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196701010130-196712312230.nc
-  hashes:
-    binhash: 9a9056c12ae79c04969b1d6de21ad0ba
-    md5: b214ae593e13018a297649ffee488f94
-work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196801010130-196812312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prsn/gr/v20190429/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196801010130-196812312230.nc
-  hashes:
-    binhash: 64e9e9224218c9b7a741c5bce2b6d8ec
-    md5: 189f9a8cd76dbef3e044c6e3e344e86f
-work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196901010130-196912312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prsn/gr/v20190429/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196901010130-196912312230.nc
-  hashes:
-    binhash: f63c32efc64e4744986c2ba126220cd3
-    md5: 0e1e7f6e73e6ef43f40b3b1d789cac35
-work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197001010130-197012312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prsn/gr/v20190429/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197001010130-197012312230.nc
-  hashes:
-    binhash: d3457f692bba42e79c41eade8afab74f
-    md5: bb5ecefdcdbf2c87f3c2633720893636
-work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197101010130-197112312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prsn/gr/v20190429/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197101010130-197112312230.nc
-  hashes:
-    binhash: 30423215e7b1e493f16eb6265b8c71ca
-    md5: 9c57323544079e4aeb774db9224251a6
-work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197201010130-197212312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prsn/gr/v20190429/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197201010130-197212312230.nc
-  hashes:
-    binhash: a6573c85a8c4d172e6aa09890b506060
-    md5: 50bb924c3f629636597a3c556bbef7ec
-work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197301010130-197312312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prsn/gr/v20190429/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197301010130-197312312230.nc
-  hashes:
-    binhash: e0197866a8059dc94762ed60669444dd
-    md5: d64e78143b551f916bbcd47cf1dcf878
-work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197401010130-197412312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prsn/gr/v20190429/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197401010130-197412312230.nc
-  hashes:
-    binhash: 50c61202b77f34c5059e4994408e54cd
-    md5: f9468505d1a486b32cc158776891ef9f
-work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197501010130-197512312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prsn/gr/v20190429/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197501010130-197512312230.nc
-  hashes:
-    binhash: 412d615eda99f68ae1923747878afcf0
-    md5: 77436c004fefe7330115057239852061
-work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197601010130-197612312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prsn/gr/v20190429/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197601010130-197612312230.nc
-  hashes:
-    binhash: ae4ae5b005bdd65770ed0cfdfa6b0aa6
-    md5: d5da06cf728a2691bc13ad4212f983b3
-work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197701010130-197712312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prsn/gr/v20190429/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197701010130-197712312230.nc
-  hashes:
-    binhash: 2d158d0b88df1fd19f87206589baed56
-    md5: 8310220b8af6e2b3ed1e8cb55f995e09
-work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197801010130-197812312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prsn/gr/v20190429/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197801010130-197812312230.nc
-  hashes:
-    binhash: 0b556cc834d8b31f797a3bb6ab6c489b
-    md5: 990645fb88050c9fc2bb4bc7bbbbd8cb
-work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197901010130-197912312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prsn/gr/v20190429/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197901010130-197912312230.nc
-  hashes:
-    binhash: 98c772801d09ab10f52b3ef917c2a087
-    md5: b8c02220674dffb996f3a342d29fb43f
-work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198001010130-198012312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prsn/gr/v20190429/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198001010130-198012312230.nc
-  hashes:
-    binhash: 50ccbf9b6f54c77825a9a34745ac0096
-    md5: b08d16fa6fd2b93e79bdc3cb5757e894
-work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198101010130-198112312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prsn/gr/v20190429/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198101010130-198112312230.nc
-  hashes:
-    binhash: a0ed5cc6ffd1a40d3923f2295f93dd57
-    md5: d30cf6e2c764dbbc556984c3ce2c9569
-work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198201010130-198212312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prsn/gr/v20190429/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198201010130-198212312230.nc
-  hashes:
-    binhash: 458ffdd36b9c68c23648d66950e80b41
-    md5: 9b96a39fa37b07e190c0ffa6e793405c
-work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198301010130-198312312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prsn/gr/v20190429/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198301010130-198312312230.nc
-  hashes:
-    binhash: 51d6cb9ffc5065b372e6cb22d2fc49be
-    md5: 0156c5f0e2050fab67b42c1d7830d517
-work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198401010130-198412312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prsn/gr/v20190429/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198401010130-198412312230.nc
-  hashes:
-    binhash: a03de8b3df79ff2d1725c48ec7c7afbe
-    md5: fd0135cb16b3ae2a7c8af65d3ed10854
-work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198501010130-198512312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prsn/gr/v20190429/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198501010130-198512312230.nc
-  hashes:
-    binhash: 5a3e4079c3bc6e4994b3ab50cad6dfec
-    md5: d44ae3fd91de2d8f90d3650963cad8b8
-work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198601010130-198612312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prsn/gr/v20190429/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198601010130-198612312230.nc
-  hashes:
-    binhash: 54f1aefc5222adab397bb241680a6a7b
-    md5: ac7d25761ccb8339b2baf4c3000c5def
-work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198701010130-198712312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prsn/gr/v20190429/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198701010130-198712312230.nc
-  hashes:
-    binhash: 0d0d0361b007075e312ec2cdb9513376
-    md5: 57fc8ff3b73a53f161192047822079ac
-work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198801010130-198812312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prsn/gr/v20190429/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198801010130-198812312230.nc
-  hashes:
-    binhash: ad9c17fe7d137a2265c74b5e087a2226
-    md5: b8df71ef0224d644c9afde1990b28262
-work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198901010130-198912312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prsn/gr/v20190429/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198901010130-198912312230.nc
-  hashes:
-    binhash: d68d0eed6fa31e7643b2650b98b68e9a
-    md5: 808cb9c275b0a135088ddea017ca9891
-work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199001010130-199012312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prsn/gr/v20190429/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199001010130-199012312230.nc
-  hashes:
-    binhash: 508308df01527f766095730289c1db85
-    md5: 48f55a796ca4c5eecc541df2024d53c5
-work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199101010130-199112312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prsn/gr/v20190429/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199101010130-199112312230.nc
-  hashes:
-    binhash: b97bf95471858c9a89a0792008bd0528
-    md5: 96aa6cfbdb8acc603f079c8d3070883d
-work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199201010130-199212312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prsn/gr/v20190429/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199201010130-199212312230.nc
-  hashes:
-    binhash: 7e08c8271e8c114cc503b38c7ca58f1b
-    md5: 4f6f61e03e35cbcb27fa669fd933aeed
-work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199301010130-199312312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prsn/gr/v20190429/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199301010130-199312312230.nc
-  hashes:
-    binhash: f55576ee356b41b569806d8bf52b6ee2
-    md5: 424946f3c380509371c29ca65dba8aab
-work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199401010130-199412312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prsn/gr/v20190429/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199401010130-199412312230.nc
-  hashes:
-    binhash: 03b718f4bb201ce8a1b8dfa255f5f9fe
-    md5: fd0daac5ddcd1d598bf37572994acb44
-work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199501010130-199512312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prsn/gr/v20190429/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199501010130-199512312230.nc
-  hashes:
-    binhash: cfd9a8f6d09217681c6fd72ac02673f8
-    md5: 7b97f29974e6e403d87c539e1752e5e9
-work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199601010130-199612312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prsn/gr/v20190429/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199601010130-199612312230.nc
-  hashes:
-    binhash: d5759872cdb385ae73a141d731af3fa7
-    md5: 193559dac6c5942eaff4d79962a4cec3
-work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199701010130-199712312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prsn/gr/v20190429/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199701010130-199712312230.nc
-  hashes:
-    binhash: 565e3ea83ef054cd20a02def1d8502e6
-    md5: c5e8bc779eaaccecbd99d821a0bde585
-work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199801010130-199812312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prsn/gr/v20190429/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199801010130-199812312230.nc
-  hashes:
-    binhash: 0dae97c10c5e5f42ba58fbf0fc304f2b
-    md5: b7d5729633e09e8ab123b7eb093a8fe0
-work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199901010130-199912312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prsn/gr/v20190429/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199901010130-199912312230.nc
-  hashes:
-    binhash: 5bbd163b4d79a53118495b1661311083
-    md5: a47e0e800a1d3f50335049bdd7bfe70d
-work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200001010130-200012312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prsn/gr/v20190429/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200001010130-200012312230.nc
-  hashes:
-    binhash: 75294d4e0c60e8b3956e8316f8bfff6a
-    md5: 4de29b0016f57f466bb571a7b77f2f67
-work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200101010130-200112312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prsn/gr/v20190429/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200101010130-200112312230.nc
-  hashes:
-    binhash: 675fe662c554a19b6dbc0bf5e31b48d3
-    md5: 494ef4e58e58af7eb8cc5c98be901c64
-work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200201010130-200212312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prsn/gr/v20190429/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200201010130-200212312230.nc
-  hashes:
-    binhash: dccb089a03f25ea9e26a4dd75b297922
-    md5: 9cc4e57786e88e195b591407450a38ca
-work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200301010130-200312312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prsn/gr/v20190429/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200301010130-200312312230.nc
-  hashes:
-    binhash: dc996fd55b019d4108360b88847e4b73
-    md5: 0871f1973c023a4826d306f76b561c58
-work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200401010130-200412312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prsn/gr/v20190429/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200401010130-200412312230.nc
-  hashes:
-    binhash: ab2d27524b2fccb946b4b5d276e86dba
-    md5: f7acab0b26f3c0ebdc3fcef010bece37
-work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200501010130-200512312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prsn/gr/v20190429/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200501010130-200512312230.nc
-  hashes:
-    binhash: 686efa7b766273eb71aa4172b1b5f6ab
-    md5: af15d031a7c9da4f87dc555803196437
-work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200601010130-200612312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prsn/gr/v20190429/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200601010130-200612312230.nc
-  hashes:
-    binhash: 6edccb29ecd60fd34e1e735932277b47
-    md5: eb6b3285453417cba476dba57a1b0025
-work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200701010130-200712312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prsn/gr/v20190429/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200701010130-200712312230.nc
-  hashes:
-    binhash: 4f1f9eb6c9bac1f034953b05588914f4
-    md5: 4dc013a7ab47d22f7712b25c53cd7b7f
-work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200801010130-200812312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prsn/gr/v20190429/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200801010130-200812312230.nc
-  hashes:
-    binhash: d3719ca06eca0e145ed6aa0a7bca3fcc
-    md5: 4332bca60bc0ef67f956a5e64525393a
-work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200901010130-200912312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prsn/gr/v20190429/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200901010130-200912312230.nc
-  hashes:
-    binhash: 2a54071f6b7f035719246b91616a742a
-    md5: 35e71da581ec64e7cff204dde3b4cae5
-work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201001010130-201012312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prsn/gr/v20190429/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201001010130-201012312230.nc
-  hashes:
-    binhash: c856241259faecbf2a2fd8fcbe71cec0
-    md5: e4afd887c3e138f852bcadee8b158031
-work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201101010130-201112312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prsn/gr/v20190429/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201101010130-201112312230.nc
-  hashes:
-    binhash: cbb02c7fed89f6e7da0489bb5277264d
-    md5: 5732b492928d45292447c52071e633ef
-work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201201010130-201212312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prsn/gr/v20190429/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201201010130-201212312230.nc
-  hashes:
-    binhash: bc3a370c607397686ee6361190a735c4
-    md5: 4d0fa832d74153d325dd616f03afb3df
-work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201301010130-201312312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prsn/gr/v20190429/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201301010130-201312312230.nc
-  hashes:
-    binhash: e6cd04933d87eaa4496c9bd74dec20fb
-    md5: 4e865456232964e67ae98821df01e234
-work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201401010130-201412312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prsn/gr/v20190429/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201401010130-201412312230.nc
-  hashes:
-    binhash: 7310b3e564a0d42b201d3786211f1a44
-    md5: 157c41346834686a4e85ac88f9447370
-work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201501010130-201512312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prsn/gr/v20190429/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201501010130-201512312230.nc
-  hashes:
-    binhash: 59ee00da9ab066b6e09d817075ae111c
-    md5: 7f213a9e2b1f0b0415335e3a61926b2b
-work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201601010130-201612312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prsn/gr/v20190429/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201601010130-201612312230.nc
-  hashes:
-    binhash: e5ca75247a84bda1f0337e659b6680f5
-    md5: 0956886b71a2a4af3603a1a10926a1c9
-work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201701010130-201712312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prsn/gr/v20190429/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201701010130-201712312230.nc
-  hashes:
-    binhash: 4a21f5663b43da3d0e40e20b4ad94ea9
-    md5: 9136542a7a7e3b0bc91c2bad5fea29c3
-work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201801010130-201812312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prsn/gr/v20190429/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201801010130-201812312230.nc
-  hashes:
-    binhash: fbcd39aa88ebb6cba35d5e9250decfef
-    md5: a341e33aa7036c3098243210af9c3fd4
-work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201901010130-201901052230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/prsn/gr/v20190429/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201901010130-201901052230.nc
-  hashes:
-    binhash: 158307894d644602f5be27121f78eaac
-    md5: e115f1138748febed28760e9cf56a147
-work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_195801010000-195812312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/psl/gr/v20190429/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_195801010000-195812312100.nc
-  hashes:
-    binhash: 5b51f30fbb735e985d43673f577cb598
-    md5: aee934eae430d5cc3df30f24131f88df
-work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_195901010000-195912312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/psl/gr/v20190429/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_195901010000-195912312100.nc
-  hashes:
-    binhash: 8c5097ee2891b2353b38a388c53f8439
-    md5: 9bd86a112ba04c8890a960e8f4cb270d
-work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196001010000-196012312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/psl/gr/v20190429/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196001010000-196012312100.nc
-  hashes:
-    binhash: 0a1c8e3b377097ac988de1cde9517c7c
-    md5: c7feac356e8d7f743439b946ff1cb07a
-work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196101010000-196112312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/psl/gr/v20190429/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196101010000-196112312100.nc
-  hashes:
-    binhash: d18b1f22befe092b274899bc55649c48
-    md5: c55bd9c33c6a066b4b54936640a901ed
-work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196201010000-196212312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/psl/gr/v20190429/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196201010000-196212312100.nc
-  hashes:
-    binhash: d08277f4dbc6e0114ebf7047ea96694a
-    md5: 2da97ee1059702628d0d85f842446c8a
-work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196301010000-196312312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/psl/gr/v20190429/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196301010000-196312312100.nc
-  hashes:
-    binhash: 05deb1d7b493de2027bea61844867cb3
-    md5: 6f4d2e33a787296458711ed2bf11dc8f
-work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196401010000-196412312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/psl/gr/v20190429/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196401010000-196412312100.nc
-  hashes:
-    binhash: a17eb4e3f29154eae09c1304426afccc
-    md5: 3d9ee2245685d167ab3a3943972301bd
-work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196501010000-196512312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/psl/gr/v20190429/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196501010000-196512312100.nc
-  hashes:
-    binhash: 5ed8fece232853f6b40319beb9a4ec3a
-    md5: 498476fe2604514e9a6de1af3af82972
-work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196601010000-196612312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/psl/gr/v20190429/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196601010000-196612312100.nc
-  hashes:
-    binhash: b9f347d8c4b9b934080f07e936aa58c8
-    md5: 5ce61950c7cc9f6f04b5180b081a268f
-work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196701010000-196712312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/psl/gr/v20190429/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196701010000-196712312100.nc
-  hashes:
-    binhash: 0052707aa4ac552532657b9eaec3b4d0
-    md5: bed5eac61da93d9f78d34c7d736c426b
-work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196801010000-196812312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/psl/gr/v20190429/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196801010000-196812312100.nc
-  hashes:
-    binhash: d0026401579e01b1ed390b67db1f9762
-    md5: d35e9c1e7cec1bada2455f4a6f57fcfe
-work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196901010000-196912312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/psl/gr/v20190429/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196901010000-196912312100.nc
-  hashes:
-    binhash: 8dd27acece3323db8d41a913d19f9de8
-    md5: 58e10aae45cd33be7e54b233b14cf665
-work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197001010000-197012312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/psl/gr/v20190429/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197001010000-197012312100.nc
-  hashes:
-    binhash: 0653c5426b9ba94890137a22b6cfef10
-    md5: 289d08c408fc559dd74d369b220c3b79
-work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197101010000-197112312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/psl/gr/v20190429/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197101010000-197112312100.nc
-  hashes:
-    binhash: cc7419d380fc12228f7a799f6465afa1
-    md5: e96243f61f405f02507ed247b7b8aaa6
-work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197201010000-197212312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/psl/gr/v20190429/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197201010000-197212312100.nc
-  hashes:
-    binhash: 03ea788a242706bfe132091d6909c189
-    md5: 1586e6c9abb7717a35d6efe40799b489
-work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197301010000-197312312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/psl/gr/v20190429/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197301010000-197312312100.nc
-  hashes:
-    binhash: ade850576cdff3682126ffc252cabd28
-    md5: f322cd782cbedc02a83a3a350b0274c8
-work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197401010000-197412312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/psl/gr/v20190429/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197401010000-197412312100.nc
-  hashes:
-    binhash: 3f6ab488dae3e026366bbc5366e3cdfe
-    md5: 94a7869d591c2e26adb331a3122c1243
-work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197501010000-197512312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/psl/gr/v20190429/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197501010000-197512312100.nc
-  hashes:
-    binhash: 57c1c70f5c648419f5a08bb4e5cd70f7
-    md5: 10ffdcbd4bf3017d9165fe420fee5682
-work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197601010000-197612312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/psl/gr/v20190429/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197601010000-197612312100.nc
-  hashes:
-    binhash: 0735cac9c3357bae29f624e62f399632
-    md5: 103cc25c968a103e0c045d16a38d5d65
-work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197701010000-197712312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/psl/gr/v20190429/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197701010000-197712312100.nc
-  hashes:
-    binhash: c462602627f79f6f73390ed65d8e2fd1
-    md5: fe41ca934da2fef5219dfb6b6a037a7c
-work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197801010000-197812312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/psl/gr/v20190429/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197801010000-197812312100.nc
-  hashes:
-    binhash: 4d9b149cf27ac11751f79f961ae3aa9b
-    md5: a6c7139e67ecc7ceb97cec2dff764b20
-work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197901010000-197912312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/psl/gr/v20190429/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197901010000-197912312100.nc
-  hashes:
-    binhash: d1d51a0f79dcee37b9450d80fe04977d
-    md5: bb349c344d8786c190f826169f55f91a
-work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198001010000-198012312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/psl/gr/v20190429/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198001010000-198012312100.nc
-  hashes:
-    binhash: 26310110a155fd3775eacfed3094b629
-    md5: de3e23caa7d74ffe6ce697a30acdc812
-work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198101010000-198112312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/psl/gr/v20190429/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198101010000-198112312100.nc
-  hashes:
-    binhash: db200ce665b7fbbf1b3f1b8d717f0d30
-    md5: 05e7a75197021688c0291ab9c50f4790
-work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198201010000-198212312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/psl/gr/v20190429/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198201010000-198212312100.nc
-  hashes:
-    binhash: 6a2020c3e207dd032e1ae253753491fb
-    md5: a67bebde9113447ac6f0236d99002368
-work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198301010000-198312312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/psl/gr/v20190429/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198301010000-198312312100.nc
-  hashes:
-    binhash: 8ef707fe2590a421ec83ede738bdec1e
-    md5: 010547bd252b4b3a5f64f6f911f750d9
-work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198401010000-198412312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/psl/gr/v20190429/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198401010000-198412312100.nc
-  hashes:
-    binhash: 87d06394bb3774f204e6eeb4a693ac1f
-    md5: 77a2e6fe0c621c4e7a8b3a0778c3aeac
-work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198501010000-198512312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/psl/gr/v20190429/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198501010000-198512312100.nc
-  hashes:
-    binhash: ffac44a5ba5b60e8d98be0ca6acc73cb
-    md5: 7f618f4c674327a8fe6a65f0f7531ba3
-work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198601010000-198612312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/psl/gr/v20190429/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198601010000-198612312100.nc
-  hashes:
-    binhash: fe96bd99158e16d078b5359ae0fe078b
-    md5: 396305cc8f71ff51eedef278a1cfe667
-work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198701010000-198712312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/psl/gr/v20190429/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198701010000-198712312100.nc
-  hashes:
-    binhash: e0822133fa2dbbd259bcd44f6743ae28
-    md5: c636c8a6d62210c3ec6393e843ef4051
-work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198801010000-198812312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/psl/gr/v20190429/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198801010000-198812312100.nc
-  hashes:
-    binhash: 63aa419f82029f1cc9da0ee1ae99f68f
-    md5: 2c6ec3f851542324a5323667b1a857f1
-work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198901010000-198912312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/psl/gr/v20190429/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198901010000-198912312100.nc
-  hashes:
-    binhash: 77258c7ba9a7e7f0a87050bb62551d6b
-    md5: 980b6d36f862abe041d9ce241f23b63f
-work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199001010000-199012312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/psl/gr/v20190429/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199001010000-199012312100.nc
-  hashes:
-    binhash: 744d07b7bafc30de28b7c739c8d1a237
-    md5: 6995482777cf21058e5af348f199be3b
-work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199101010000-199112312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/psl/gr/v20190429/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199101010000-199112312100.nc
-  hashes:
-    binhash: 99e2c12b1583a2da2a621f6c10342be8
-    md5: d0db757f7886cccddeca5b9e49562c27
-work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199201010000-199212312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/psl/gr/v20190429/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199201010000-199212312100.nc
-  hashes:
-    binhash: 33da828b0d900956113f81ba75fed136
-    md5: 9934239a93ce017cc9e17d36cbd10170
-work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199301010000-199312312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/psl/gr/v20190429/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199301010000-199312312100.nc
-  hashes:
-    binhash: 37e31008432e915df74655fd75cb1bea
-    md5: acc074b614958c0c453bf15b81a41c10
-work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199401010000-199412312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/psl/gr/v20190429/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199401010000-199412312100.nc
-  hashes:
-    binhash: b03e5b8cefec0273492b8b9c53f5adfd
-    md5: a8e58eedd7f4674e10042b9157d66be5
-work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199501010000-199512312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/psl/gr/v20190429/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199501010000-199512312100.nc
-  hashes:
-    binhash: 4d12d209992d8a6350b61c5bcbc94cac
-    md5: e0ef17abfd646cf6d13d1da9dc68a3d1
-work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199601010000-199612312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/psl/gr/v20190429/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199601010000-199612312100.nc
-  hashes:
-    binhash: 21d46a9dc74f72f4e2bfc94e5b70e6ff
-    md5: fd0340bff06a581e07a43cbd46d62720
-work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199701010000-199712312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/psl/gr/v20190429/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199701010000-199712312100.nc
-  hashes:
-    binhash: c8cfc60cd0bdd23b9dabbe4036676fb3
-    md5: edce9f1158d81c6a113050fa8b573cd9
-work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199801010000-199812312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/psl/gr/v20190429/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199801010000-199812312100.nc
-  hashes:
-    binhash: 3402a983b18bbf8c62df0515cbc31729
-    md5: 9ce4c731e436edc2df22d03d00347e9d
-work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199901010000-199912312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/psl/gr/v20190429/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199901010000-199912312100.nc
-  hashes:
-    binhash: f4505140bc7c26cd1d1b56fe26f42398
-    md5: 147c787c3a6145f797e2a88c12aa8c8a
-work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200001010000-200012312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/psl/gr/v20190429/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200001010000-200012312100.nc
-  hashes:
-    binhash: d387e17f0481b51495058696a62db0c1
-    md5: 4cedc6140651ca18f0a75e3c653c2fa8
-work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200101010000-200112312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/psl/gr/v20190429/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200101010000-200112312100.nc
-  hashes:
-    binhash: 2c567ccb881de5adf23ccb66062375ae
-    md5: cdc793053ab3f49d5f11e6a8892bc957
-work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200201010000-200212312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/psl/gr/v20190429/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200201010000-200212312100.nc
-  hashes:
-    binhash: 824578cbbb9a0106d88d2a179b33f3c7
-    md5: abd50fca4d51a3df640f8453dfa11210
-work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200301010000-200312312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/psl/gr/v20190429/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200301010000-200312312100.nc
-  hashes:
-    binhash: 7863a385de8d145167a74301947a2002
-    md5: 2ff0ea9339639aef46aac1ba210fbc87
-work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200401010000-200412312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/psl/gr/v20190429/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200401010000-200412312100.nc
-  hashes:
-    binhash: b50a1f5ea052ea45fadb09be38637682
-    md5: cb2a01b20d99b8526b8a482e087a0192
-work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200501010000-200512312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/psl/gr/v20190429/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200501010000-200512312100.nc
-  hashes:
-    binhash: 21fe3d4fa052c134bd8e1e799fcdcf60
-    md5: dc64ff4c806cbd232bf16f68299794a9
-work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200601010000-200612312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/psl/gr/v20190429/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200601010000-200612312100.nc
-  hashes:
-    binhash: 8fca36d3923361f8892d025543acc57a
-    md5: 174f3e51058e448ea1c38f529ef9ab82
-work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200701010000-200712312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/psl/gr/v20190429/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200701010000-200712312100.nc
-  hashes:
-    binhash: 06222a43e96245cce4c15a9191dcee71
-    md5: 6fe0b9073cd7fc625aa11fca66651dee
-work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200801010000-200812312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/psl/gr/v20190429/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200801010000-200812312100.nc
-  hashes:
-    binhash: aedde6b83f9dceae4281012772393b94
-    md5: 6b9bbc0f975bf85d49a3a5b6e08eed5a
-work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200901010000-200912312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/psl/gr/v20190429/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200901010000-200912312100.nc
-  hashes:
-    binhash: ff54bb0a742fa798b2b02dac4ae3e9a2
-    md5: 9a5c770307b5ff75d6cf6d0161e1f7f2
-work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201001010000-201012312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/psl/gr/v20190429/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201001010000-201012312100.nc
-  hashes:
-    binhash: 0f6912b9a1ec9313cf5389c0adeef58f
-    md5: 09a9ec3f93ac2465ce50a025a186a7e5
-work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201101010000-201112312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/psl/gr/v20190429/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201101010000-201112312100.nc
-  hashes:
-    binhash: 9d5345289ec3aba568f017728f8b9b96
-    md5: 6817406df3ba3c0b0d799dfe216b2606
-work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201201010000-201212312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/psl/gr/v20190429/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201201010000-201212312100.nc
-  hashes:
-    binhash: dd4950dbafc1c4da22dde93097c6ba31
-    md5: 6128d9b6fe91d3f9caf7403e39b03331
-work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201301010000-201312312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/psl/gr/v20190429/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201301010000-201312312100.nc
-  hashes:
-    binhash: 415ae8d3c74f246e2f19502b21c352a6
-    md5: 4c5252f6aa1fa5518e699ee9d6d9f1d7
-work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201401010000-201412312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/psl/gr/v20190429/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201401010000-201412312100.nc
-  hashes:
-    binhash: 87f7e34d3911a2a81d9f7d806b08128b
-    md5: 2b0e2187f50329ef2f9c1905c9643922
-work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201501010000-201512312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/psl/gr/v20190429/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201501010000-201512312100.nc
-  hashes:
-    binhash: f4767181e87b31091483ee696c607538
-    md5: fca6054b18245608f91cc4ab646a3aa1
-work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201601010000-201612312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/psl/gr/v20190429/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201601010000-201612312100.nc
-  hashes:
-    binhash: a0a676b3597aacfb733b11d736a1d6a9
-    md5: 855809a4411f5be63f44f6b176692a43
-work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201701010000-201712312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/psl/gr/v20190429/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201701010000-201712312100.nc
-  hashes:
-    binhash: 860a1715970f77a659b7e659b4e00497
-    md5: 2fa5043672deea7beebd62b48388b9ec
-work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201801010000-201812312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/psl/gr/v20190429/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201801010000-201812312100.nc
-  hashes:
-    binhash: ec4b54a0646b761ae6008671e896ba28
-    md5: 094a7fc74ae7247125ea667e357b0da5
-work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201901010000-201901052100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/psl/gr/v20190429/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201901010000-201901052100.nc
-  hashes:
-    binhash: 8cce5acef47caaef844653b8565970d8
-    md5: 9433ee01eeb6b9f1dad59a67cfc63b0f
-work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_195801010130-195812312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rlds/gr/v20190429/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_195801010130-195812312230.nc
-  hashes:
-    binhash: 1a5cc4474bc4531e4afde08b031e8708
-    md5: 3e8958190f1fbf9cd593fc165372b955
-work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_195901010130-195912312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rlds/gr/v20190429/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_195901010130-195912312230.nc
-  hashes:
-    binhash: 4cc56017cc5793fd528e6150f3ea24b2
-    md5: a0b83d083f01c3e53693f5d8412704f7
-work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196001010130-196012312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rlds/gr/v20190429/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196001010130-196012312230.nc
-  hashes:
-    binhash: 9deab19dd497c1d86437053f96b5471d
-    md5: be4f4d4959b371ba07ae5aafd288309e
-work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196101010130-196112312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rlds/gr/v20190429/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196101010130-196112312230.nc
-  hashes:
-    binhash: 6b215de966a39d89f0e6305e7cd1e49c
-    md5: e1b2d4c713e29c9c08c7d2e7ad5c37ab
-work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196201010130-196212312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rlds/gr/v20190429/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196201010130-196212312230.nc
-  hashes:
-    binhash: 80c91fdbfb3ebb464a1a9ff914e09d51
-    md5: 8e18c7818a7624fc13ac95210adb8bd5
-work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196301010130-196312312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rlds/gr/v20190429/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196301010130-196312312230.nc
-  hashes:
-    binhash: 8d04f4bf2a01a914f9a7fa7b57eb29a8
-    md5: 2538f7637b1099aaa0b06c17e42eaecc
-work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196401010130-196412312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rlds/gr/v20190429/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196401010130-196412312230.nc
-  hashes:
-    binhash: ede39e7023b6ae0465e42adba7ac054d
-    md5: 5f490110eae36b90a8786567875bfbdb
-work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196501010130-196512312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rlds/gr/v20190429/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196501010130-196512312230.nc
-  hashes:
-    binhash: 84c926add2dc8f0f1b98bbc91f46f6df
-    md5: 1d060e87c703cf69135fa5123683b72e
-work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196601010130-196612312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rlds/gr/v20190429/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196601010130-196612312230.nc
-  hashes:
-    binhash: 4fdb268b092788b72bf71cded2044614
-    md5: b1645048846eafada4554a34d22307da
-work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196701010130-196712312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rlds/gr/v20190429/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196701010130-196712312230.nc
-  hashes:
-    binhash: 7826622db72eaab7ab69f4e1fff3e5c3
-    md5: 59308cbd89984d4051d05641345e10f0
-work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196801010130-196812312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rlds/gr/v20190429/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196801010130-196812312230.nc
-  hashes:
-    binhash: 518f807f3f451f5c22c1b7c8b4022dc9
-    md5: 137988eba1307ca0dd88366745f7876d
-work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196901010130-196912312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rlds/gr/v20190429/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196901010130-196912312230.nc
-  hashes:
-    binhash: 61726f1d8cb99a92cb20588c7e758e5b
-    md5: 940925ab15e34f29e1912a3cf29a85a9
-work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197001010130-197012312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rlds/gr/v20190429/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197001010130-197012312230.nc
-  hashes:
-    binhash: 01250aa35d23cc4c4d58700add775e39
-    md5: ad63d0ecf7d66c815e381cbf416431f4
-work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197101010130-197112312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rlds/gr/v20190429/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197101010130-197112312230.nc
-  hashes:
-    binhash: 297209ce6e23ba3d2a00caa58b0903e7
-    md5: 59a8b789f09f3fc6f8697fda16b0222c
-work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197201010130-197212312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rlds/gr/v20190429/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197201010130-197212312230.nc
-  hashes:
-    binhash: 253da2a2d2fba2ef54f575c0958c5694
-    md5: efc3b916f47f970d521a70be4c9d1d62
-work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197301010130-197312312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rlds/gr/v20190429/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197301010130-197312312230.nc
-  hashes:
-    binhash: 6aaf17834e4d507b268ad1ce13ffb792
-    md5: 36ce173350194fd809761bd9526ca390
-work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197401010130-197412312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rlds/gr/v20190429/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197401010130-197412312230.nc
-  hashes:
-    binhash: ab92f637b6865ae393532af40a924870
-    md5: 152f9925f527f40c6ccc92988150ddc0
-work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197501010130-197512312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rlds/gr/v20190429/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197501010130-197512312230.nc
-  hashes:
-    binhash: 4f0756a982e9c956d08ec3291e807a33
-    md5: ff7cad474d6ce0e30c7fcf70139a92b7
-work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197601010130-197612312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rlds/gr/v20190429/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197601010130-197612312230.nc
-  hashes:
-    binhash: cdb38df1d018b3932cd84930d8aa4f49
-    md5: 2822187cd10217ca9a948a9465209bb3
-work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197701010130-197712312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rlds/gr/v20190429/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197701010130-197712312230.nc
-  hashes:
-    binhash: df5ba0c726240c996ee03053fd62a369
-    md5: 498dc1fe8623b9b10fb3dbd40a9a378a
-work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197801010130-197812312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rlds/gr/v20190429/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197801010130-197812312230.nc
-  hashes:
-    binhash: be7c9954865a9cd1ddc8f137570387e9
-    md5: 7414eb8c460891c0cf2c146cb8b513db
-work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197901010130-197912312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rlds/gr/v20190429/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197901010130-197912312230.nc
-  hashes:
-    binhash: b67ff050c90e81e7338df24f1e9d5ba0
-    md5: 21f33e23c119b4a71e9c2ff54316a279
-work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198001010130-198012312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rlds/gr/v20190429/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198001010130-198012312230.nc
-  hashes:
-    binhash: 3ae32293c32df30df661bf6a333934aa
-    md5: 54cfed3bb0854ea628d82e9e6451f6db
-work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198101010130-198112312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rlds/gr/v20190429/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198101010130-198112312230.nc
-  hashes:
-    binhash: 7cd7d6c3dba9babdb882f122886e81f6
-    md5: df5439cb49cb5f876d40a1bd268f22da
-work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198201010130-198212312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rlds/gr/v20190429/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198201010130-198212312230.nc
-  hashes:
-    binhash: 54d09243f2bf041ef9d4c8b4757d8957
-    md5: 8864489fa263793edb4359d6020da306
-work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198301010130-198312312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rlds/gr/v20190429/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198301010130-198312312230.nc
-  hashes:
-    binhash: 415a65e3ddc07bd55b8dc51380c6661d
-    md5: 1c151b003ca2e2ac55b4c8a08ffda654
-work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198401010130-198412312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rlds/gr/v20190429/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198401010130-198412312230.nc
-  hashes:
-    binhash: 750e5bf7719d3a4503ad5710293ad164
-    md5: 7a7f7ebf48da94735397e09dd657d3dd
-work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198501010130-198512312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rlds/gr/v20190429/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198501010130-198512312230.nc
-  hashes:
-    binhash: bce09927d75cbdfd9c05c4bc8a7018af
-    md5: 2c273379f5731aba046f6692534dfce0
-work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198601010130-198612312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rlds/gr/v20190429/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198601010130-198612312230.nc
-  hashes:
-    binhash: 6f785abb832bed3da8645ff1dbd5d006
-    md5: 59d52927739d8dfe4d7f9df49da1ffee
-work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198701010130-198712312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rlds/gr/v20190429/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198701010130-198712312230.nc
-  hashes:
-    binhash: a313fbb9b5daa95a871f75cc65d882d1
-    md5: b1de6ec23501cc5e94805c5b6db7fe77
-work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198801010130-198812312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rlds/gr/v20190429/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198801010130-198812312230.nc
-  hashes:
-    binhash: 85853ff620382e48944f3376bec059bc
-    md5: 8b9fb876905fd1b596356c64f6468169
-work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198901010130-198912312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rlds/gr/v20190429/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198901010130-198912312230.nc
-  hashes:
-    binhash: 31e48dada16d35427ee457d422fcfc1e
-    md5: b26f0807375749ffb6f085ea61977f39
-work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199001010130-199012312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rlds/gr/v20190429/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199001010130-199012312230.nc
-  hashes:
-    binhash: 18e9cf9d81d9fa57a995ebc1371bd12d
-    md5: ea2a8325baffc675aab8551b3ab186a0
-work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199101010130-199112312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rlds/gr/v20190429/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199101010130-199112312230.nc
-  hashes:
-    binhash: aa6a42c8e92181eabb3841b0977a0c32
-    md5: abd540471a88b90ea13a4c0005afbdbd
-work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199201010130-199212312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rlds/gr/v20190429/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199201010130-199212312230.nc
-  hashes:
-    binhash: 24b39b7757bee2d97fc7480ec98eea7f
-    md5: 319c6e179c570cb266fec0dfbf85b5eb
-work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199301010130-199312312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rlds/gr/v20190429/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199301010130-199312312230.nc
-  hashes:
-    binhash: 8fc34abeb746e721a08b079a6748ad31
-    md5: 8d4c075b68bc821c2f8f8e8853513ebe
-work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199401010130-199412312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rlds/gr/v20190429/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199401010130-199412312230.nc
-  hashes:
-    binhash: 6fb980c69dce5a6d26a93deb5055391d
-    md5: cc5048fce4e75cf01221415304791564
-work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199501010130-199512312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rlds/gr/v20190429/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199501010130-199512312230.nc
-  hashes:
-    binhash: 9f2db6392aa0662f684434ebe0b33d3a
-    md5: 90ca6b336b092f893dd1b7417222b37d
-work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199601010130-199612312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rlds/gr/v20190429/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199601010130-199612312230.nc
-  hashes:
-    binhash: 0f0adc1fbcf7d048bbe0192547f19988
-    md5: 5e8b73dbeee3a17161ca2dc5771058df
-work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199701010130-199712312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rlds/gr/v20190429/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199701010130-199712312230.nc
-  hashes:
-    binhash: afcf04a1bab0d175f903cb450ca3ba9a
-    md5: fba68643f0f9466c0d493012d8a72c5e
-work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199801010130-199812312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rlds/gr/v20190429/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199801010130-199812312230.nc
-  hashes:
-    binhash: 15262f8e5fd5f5b0776d61ff5ffb91e6
-    md5: 122944990c67883de3e79bc9c9f3a232
-work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199901010130-199912312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rlds/gr/v20190429/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199901010130-199912312230.nc
-  hashes:
-    binhash: a2258c59d154a5717c26670ffbea5ba8
-    md5: a56f9addea8812db143ea0b961b9bf27
-work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200001010130-200012312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rlds/gr/v20190429/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200001010130-200012312230.nc
-  hashes:
-    binhash: 977afce009eb0b33b4f902a5afb7953d
-    md5: c161bf64be15c12273a556bcb0541169
-work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200101010130-200112312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rlds/gr/v20190429/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200101010130-200112312230.nc
-  hashes:
-    binhash: c2ab568b2701f03d6a41cd13dd7d640d
-    md5: 30db7152c1083f610f470390939fb57e
-work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200201010130-200212312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rlds/gr/v20190429/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200201010130-200212312230.nc
-  hashes:
-    binhash: 8e7b2ac516028faf9f3660652c29faaf
-    md5: b199fb701134b23b7b04097af40db66c
-work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200301010130-200312312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rlds/gr/v20190429/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200301010130-200312312230.nc
-  hashes:
-    binhash: d0176916693606591a8519d7b84a2ded
-    md5: e575062670d6b41dba4d5b402f8b13cb
-work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200401010130-200412312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rlds/gr/v20190429/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200401010130-200412312230.nc
-  hashes:
-    binhash: aabbd5da8d58b751f10182f1a4b6542e
-    md5: da33dd36141c90d9452522a05157482e
-work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200501010130-200512312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rlds/gr/v20190429/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200501010130-200512312230.nc
-  hashes:
-    binhash: 3a8854b52ba97adba3756c42eb4c01bb
-    md5: acaf47955c46d85c55ac3a59026cc9a4
-work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200601010130-200612312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rlds/gr/v20190429/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200601010130-200612312230.nc
-  hashes:
-    binhash: 0f7bd77659ea4883e4a28849d74e060e
-    md5: 5f8ae22a9ad3ac9ca42eec3b83fb5ab5
-work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200701010130-200712312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rlds/gr/v20190429/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200701010130-200712312230.nc
-  hashes:
-    binhash: 0ae2cd2726fb09fe045a96d7e16ac43f
-    md5: 5314a03f541e5c7b2ed5c3b31f066b31
-work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200801010130-200812312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rlds/gr/v20190429/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200801010130-200812312230.nc
-  hashes:
-    binhash: 4adbfbfbb7835209f5625b8a40f3624f
-    md5: 9482725eec844b78ffae394828e5e8bc
-work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200901010130-200912312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rlds/gr/v20190429/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200901010130-200912312230.nc
-  hashes:
-    binhash: 2d5330c97ab65ab9918d5fa290b7ac67
-    md5: fdb295398896dc546ff822c01b6c5c21
-work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201001010130-201012312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rlds/gr/v20190429/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201001010130-201012312230.nc
-  hashes:
-    binhash: d0d33961a69ba277302571e41cd1967d
-    md5: a42c6dca38a19b15e12a3b8f2efde366
-work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201101010130-201112312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rlds/gr/v20190429/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201101010130-201112312230.nc
-  hashes:
-    binhash: af302e69173c08ed625b40935e868a74
-    md5: 0b37db834d40f1449190dda26064f469
-work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201201010130-201212312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rlds/gr/v20190429/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201201010130-201212312230.nc
-  hashes:
-    binhash: 299a91958e16d90e82fbafa924da7e55
-    md5: 57d02b89bd4a26dc3827e3d7093ecb8c
-work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201301010130-201312312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rlds/gr/v20190429/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201301010130-201312312230.nc
-  hashes:
-    binhash: b54a97a8750f7b23460df5f78ff17445
-    md5: 62c0be5c14832ec76ae55d12f1c620c8
-work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201401010130-201412312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rlds/gr/v20190429/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201401010130-201412312230.nc
-  hashes:
-    binhash: 9db94ed0986d0ca4eea27b517c3fc577
-    md5: ede6e5ae999f08c42b0cbad4cd1e7f5b
-work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201501010130-201512312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rlds/gr/v20190429/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201501010130-201512312230.nc
-  hashes:
-    binhash: 9f96edbd1e4c1d309df6e8f6f93823a9
-    md5: 4f4af4611505d1d7d5fdbd316ae5a0c6
-work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201601010130-201612312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rlds/gr/v20190429/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201601010130-201612312230.nc
-  hashes:
-    binhash: 00268142fcb881111ee05b47f8e7ed34
-    md5: e43dc664d68d3f1c3c1cd304df353039
-work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201701010130-201712312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rlds/gr/v20190429/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201701010130-201712312230.nc
-  hashes:
-    binhash: 24ace9257748175ffc092093cebc4a76
-    md5: 88fe28b3c79b55e7e1a8108f581bc827
-work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201801010130-201812312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rlds/gr/v20190429/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201801010130-201812312230.nc
-  hashes:
-    binhash: f34891ae40d650612cb11895ff213946
-    md5: efa315c0d1f1610b0a5600db1489a259
-work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201901010130-201901052230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rlds/gr/v20190429/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201901010130-201901052230.nc
-  hashes:
-    binhash: f1a3c4313a4f6ff631f0fe887a849153
-    md5: 3d08213bdacd00ba2cfde806cf6d6b6f
+work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19580101-19581231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19580101-19581231.nc
+  hashes:
+    binhash: 142c4895f716edb195bd843575f88e4a
+    md5: 993ac575f7896e92c1035ad167688e8c
+work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19590101-19591231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19590101-19591231.nc
+  hashes:
+    binhash: 173fc9bd16a43dac2aa7dd602d7b31b2
+    md5: 4bad803afe617657179c8150b56449e8
+work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19600101-19601231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19600101-19601231.nc
+  hashes:
+    binhash: 9693275f3b7c6c2fe799845d48f1507f
+    md5: 3912d3ef2aff3df6107e3b65af23ad1f
+work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19610101-19611231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19610101-19611231.nc
+  hashes:
+    binhash: 10d37fb1601d64d6b02b70422d8fa867
+    md5: 08e9943c6e47bfc82c8681f6bf38dd08
+work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19620101-19621231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19620101-19621231.nc
+  hashes:
+    binhash: 970687bf0c424a64854002adbeb635f6
+    md5: 4b084c3b9946844382df3857763b4ed8
+work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19630101-19631231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19630101-19631231.nc
+  hashes:
+    binhash: 8826e0156fb773260240fe1544eddf7f
+    md5: 6b0b0b1c04a6f60e11739cd1f4fae123
+work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19640101-19641231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19640101-19641231.nc
+  hashes:
+    binhash: b17b6e7fa7eb81cba441f4fc8fc9ab35
+    md5: 6015b3805612bc60af66812d75158bba
+work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19650101-19651231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19650101-19651231.nc
+  hashes:
+    binhash: fa20b67beb890707cf1e956581c62897
+    md5: 2b442b9c223a6527058fa98996a0fc6f
+work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19660101-19661231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19660101-19661231.nc
+  hashes:
+    binhash: a13236ed7ff8a38b26a0b27de3739f81
+    md5: 9b766d337c5a1f14f156710516e17150
+work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19670101-19671231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19670101-19671231.nc
+  hashes:
+    binhash: cbbd0a021970bc011a2b75a68b6ec265
+    md5: 39f8703a42448fbde8e5d65ce87dd122
+work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19680101-19681231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19680101-19681231.nc
+  hashes:
+    binhash: d53a2d069595d104abb0bff0fc65311a
+    md5: 20e9d8be324c86daae54d7fe441e778d
+work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19690101-19691231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19690101-19691231.nc
+  hashes:
+    binhash: 82372b641bd5f2dd49e1f66ca2dfbc58
+    md5: 08f3ab1ad1beb9842ea9fb4f37c2c882
+work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19700101-19701231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19700101-19701231.nc
+  hashes:
+    binhash: fd432257ae03b910aad489e2b228b21b
+    md5: a5a51bcbda70248cb5a59c2714a39380
+work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19710101-19711231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19710101-19711231.nc
+  hashes:
+    binhash: e27a05628d4fa57a2d30345a124f8988
+    md5: 26edc2a2c6fa98aa7e9ebfedcc584244
+work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19720101-19721231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19720101-19721231.nc
+  hashes:
+    binhash: 25be5582d462e9b1f4241ff59574c40d
+    md5: 19bb0207ccc087f228fb52fa4e17fed5
+work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19730101-19731231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19730101-19731231.nc
+  hashes:
+    binhash: 577a6794c7af4be9f746a86e42661b48
+    md5: 916974a061a5e832df80774dd4c48b92
+work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19740101-19741231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19740101-19741231.nc
+  hashes:
+    binhash: f85ab79a4faf2a5de97b907e688ec380
+    md5: abd9e4d2f8e87e10c068f004dd0351ae
+work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19750101-19751231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19750101-19751231.nc
+  hashes:
+    binhash: 56082d3984e191ce39b4a44ac6d9ff52
+    md5: 3b2c4709162cfa50fcdcfa0f71af0bec
+work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19760101-19761231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19760101-19761231.nc
+  hashes:
+    binhash: bc1646b1b43fff24e8095caf6144ec6d
+    md5: c383a111e4b3f8daca00dd2490dea3fc
+work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19770101-19771231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19770101-19771231.nc
+  hashes:
+    binhash: c5d610a8a24202b81f12fc2d145287af
+    md5: 836877c034419ecfccc7f15a85b99646
+work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19780101-19781231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19780101-19781231.nc
+  hashes:
+    binhash: 0c9d0440dc057590dc704be78fd3ffbd
+    md5: 38f93f29dad92a1b81e1aa0c767f27c6
+work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19790101-19791231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19790101-19791231.nc
+  hashes:
+    binhash: c955b7db469e230093da36203281a57b
+    md5: 4aaa7b6e97617deb9ea74ff72e38e124
+work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19800101-19801231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19800101-19801231.nc
+  hashes:
+    binhash: cb863b480c1efefb63df6ce3c2182880
+    md5: 25b59ccff1a010901c679cf962f2a9ca
+work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19810101-19811231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19810101-19811231.nc
+  hashes:
+    binhash: 0ab646f883038c5b55b0d760bbd73fb8
+    md5: bb2c32393d383f460341292771242663
+work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19820101-19821231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19820101-19821231.nc
+  hashes:
+    binhash: 6d18e5831273592d6a67e66899ccd312
+    md5: 5978af0b63feca2f315a2ce701f2cd69
+work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19830101-19831231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19830101-19831231.nc
+  hashes:
+    binhash: 7f708032bc9ee466b9d16567fe36077c
+    md5: 39d02024634abe6b4b61ced3167a8675
+work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19840101-19841231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19840101-19841231.nc
+  hashes:
+    binhash: 209efe6f64db76d48082885f6d518f95
+    md5: e9d016194a7b315b82b4caaecba2cb5b
+work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19850101-19851231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19850101-19851231.nc
+  hashes:
+    binhash: ba5bcf9bdec92f2cd53e0379b44472b0
+    md5: 0fb36307e1dc1fe058ab3be4bb2f6f50
+work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19860101-19861231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19860101-19861231.nc
+  hashes:
+    binhash: 1d12c5522a2b275c2217a9eecc93d6f2
+    md5: e17f66dcc98027d144e2b4f5073823c1
+work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19870101-19871231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19870101-19871231.nc
+  hashes:
+    binhash: be8e4f9fb9a68c3a533e59fc85013c99
+    md5: 19df21f0525865920b0575ccc95f3b59
+work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19880101-19881231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19880101-19881231.nc
+  hashes:
+    binhash: dd7ce4f1712da998776bc28de718cf1e
+    md5: 41e9f95081865c5f246ff85199187951
+work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19890101-19891231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19890101-19891231.nc
+  hashes:
+    binhash: f0dd2944d0c195bfc17a09e16b465344
+    md5: 659f952621f9b075f4deab8d6beb4b31
+work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19900101-19901231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19900101-19901231.nc
+  hashes:
+    binhash: 6395889c8fd447cbd1684e0814ea87dc
+    md5: d95a744de35e8b947d89dcfcf8eaf1bf
+work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19910101-19911231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19910101-19911231.nc
+  hashes:
+    binhash: cd50741f135ac038b970f79605e6bb30
+    md5: 2671c3270e63f3420e3ca3d59ee14c27
+work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19920101-19921231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19920101-19921231.nc
+  hashes:
+    binhash: ab080e3219d773888ecf6acf047d081f
+    md5: 31004e715e75b0e09c395495451da03c
+work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19930101-19931231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19930101-19931231.nc
+  hashes:
+    binhash: 213dc0094ffdec7b11b13ff2d186d8f7
+    md5: 314ccbdbe2c5f84c68f345f0e8364e07
+work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19940101-19941231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19940101-19941231.nc
+  hashes:
+    binhash: 9ee23f40b1ad7ed6fc292525676d534e
+    md5: 6338d4c84f3c49364196ec33a8c9d9e7
+work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19950101-19951231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19950101-19951231.nc
+  hashes:
+    binhash: cf278ad2d5452f7f848d8cadb44c2854
+    md5: 371c62d354be44d4d38e77f6591ac2c0
+work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19960101-19961231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19960101-19961231.nc
+  hashes:
+    binhash: c2fb3ac6d6e165debaacbc89bd907010
+    md5: 1f4b21795dc6e5d4c1bdf23a346e4f1a
+work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19970101-19971231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19970101-19971231.nc
+  hashes:
+    binhash: 3752d4b27def407913eaa8d70b262396
+    md5: 81e94b4cbf532623168b1b3652a77043
+work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19980101-19981231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19980101-19981231.nc
+  hashes:
+    binhash: 8208bed6da4a70e81d9bb922fc119d78
+    md5: c4396a6bbfbea044aa3bd5c014757954
+work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19990101-19991231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19990101-19991231.nc
+  hashes:
+    binhash: 195aef6199e440a94daee44efeccd1f4
+    md5: e2d925cf6f821adb2c1e328a7085024f
+work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20000101-20001231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20000101-20001231.nc
+  hashes:
+    binhash: d999ea68a9a87a98d18026439ad2a993
+    md5: a56ef074749bf2d9f52f7d13e648943f
+work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20010101-20011231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20010101-20011231.nc
+  hashes:
+    binhash: 4f412a3372692e9225173ae51549c4eb
+    md5: 1cef39e7e1975f6bc7338da9f371506e
+work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20020101-20021231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20020101-20021231.nc
+  hashes:
+    binhash: 9bad9a5279ac489947bcdf98f7f6ade8
+    md5: 059a2b44991940a941bdb0064c820631
+work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20030101-20031231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20030101-20031231.nc
+  hashes:
+    binhash: 9cd6657c4af9e7528e9de597d490e571
+    md5: 3f66288de14c72becf94dc680816500a
+work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20040101-20041231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20040101-20041231.nc
+  hashes:
+    binhash: 1d2ad474145408dbb72e0308b2125ea7
+    md5: e7a23aaf27e34d6dbffa55632aa7c085
+work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20050101-20051231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20050101-20051231.nc
+  hashes:
+    binhash: c06d19df12c6ae78d3b9c54f36b5e452
+    md5: f60be53128f26887788509c1954d3c20
+work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20060101-20061231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20060101-20061231.nc
+  hashes:
+    binhash: d3e6296a0509c8e229221c504857a387
+    md5: bb5c5f5a9d0224ce3b7dcce03ade5340
+work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20070101-20071231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20070101-20071231.nc
+  hashes:
+    binhash: 631edf516141eb08b6111ca7a82dde44
+    md5: 2dc6d7a27c8caecdd064b24abdd6bf5e
+work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20080101-20081231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20080101-20081231.nc
+  hashes:
+    binhash: 78db310962f3b968d6c09536bb4a8f85
+    md5: c048428c73839c81ecd58b756b497bf6
+work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20090101-20091231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20090101-20091231.nc
+  hashes:
+    binhash: c2cccb43351592718bdcb0e89ebfd5cd
+    md5: 13e0e3337347d4da8eb7c037165d542c
+work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20100101-20101231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20100101-20101231.nc
+  hashes:
+    binhash: 60168abdddc2222a3bfb3cdc72b4090c
+    md5: 26cb1d8ebed0f1d27d2b3c0d01d23828
+work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20110101-20111231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20110101-20111231.nc
+  hashes:
+    binhash: 3465dfcfa3409f0e3ec2df8f86892b9a
+    md5: bed86d3cc5974dce8dff688c13168233
+work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20120101-20121231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20120101-20121231.nc
+  hashes:
+    binhash: 350247aeaaccef00d438195e44035854
+    md5: b9e606bd8f53ea29972038c8c6262ba4
+work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20130101-20131231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20130101-20131231.nc
+  hashes:
+    binhash: 886f2cf20dc6829b9f1ebf555d859edf
+    md5: dc38b1146623a792ea548d9b7f281813
+work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20140101-20141231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20140101-20141231.nc
+  hashes:
+    binhash: d8b10c76e455f90809d4ba459d4e680d
+    md5: 9da0c3e52f06ace8c78c937a2047dfca
+work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20150101-20151231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20150101-20151231.nc
+  hashes:
+    binhash: 248f57b226350d840ee7f05d834e4a84
+    md5: 99d795c98990be92a6d2ffaaa9365af3
+work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20160101-20161231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20160101-20161231.nc
+  hashes:
+    binhash: ecd2fbd8daa27302cc1f5e792469b5e1
+    md5: 153496b7ce5fe424e3e8ca372ada3157
+work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20170101-20171231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20170101-20171231.nc
+  hashes:
+    binhash: c807061715d41ae298d92ff552080d4d
+    md5: e50dd1d653f8f3e7cb57c4114bad85b1
+work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20180101-20181231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20180101-20181231.nc
+  hashes:
+    binhash: ee7df12b4b07bb13a038e6dc0b87f220
+    md5: 2f67f506411ecebeb9ded30185cd56bd
+work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20190101-20191231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20190101-20191231.nc
+  hashes:
+    binhash: 3e7b9be576239dd452ca3f3a214044c6
+    md5: b4316f8a0c1553121893c6e65f4c4cba
+work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20200101-20201231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20200101-20201231.nc
+  hashes:
+    binhash: f4be04348aaf11a7da575d74ce03ac7b
+    md5: 083de58b426b44650cd39b0fe93e24e9
+work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20210101-20211231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20210101-20211231.nc
+  hashes:
+    binhash: 9b955660971cd78f8c019ddca25ebf94
+    md5: da6abd6db1f1bae9881cb4d707439e58
+work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20220101-20221231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20220101-20221231.nc
+  hashes:
+    binhash: c30ee08b180badd003d444fcb175da3e
+    md5: 308f3506cd5849e9c85efd8e444f61c0
+work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20230101-20231231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20230101-20231231.nc
+  hashes:
+    binhash: 362afca845513bd7565ef671fe649ef2
+    md5: cde6a56649ee07c9b2399bfbda26428c
+work/atmosphere/INPUT/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20240101-20240201.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/land/day/friver/gr/v20240531/friver_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20240101-20240201.nc
+  hashes:
+    binhash: a73766f67561dc85e876d605faf7583b
+    md5: 458d2577a84ee5899e0226f18238ca9a
+work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_195801010000-195812312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_195801010000-195812312100.nc
+  hashes:
+    binhash: 3ca93de1198f88fbf740b1e4e37d231a
+    md5: 5d687abaa26b238bae05d076d63300cd
+work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_195901010000-195912312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_195901010000-195912312100.nc
+  hashes:
+    binhash: 5eaca6f19b171f65088d142d14b116dd
+    md5: a49566a0de8b21beaeba2ace01a70a7f
+work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196001010000-196012312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196001010000-196012312100.nc
+  hashes:
+    binhash: abdf7a36a78ecf8f772c6aff9e00390b
+    md5: b92ca27af1383e759fc8271b2547eb50
+work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196101010000-196112312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196101010000-196112312100.nc
+  hashes:
+    binhash: fd878db3e1967a9d7fe3a49cea59174c
+    md5: 82fa393682b9269e845a64b101eb1706
+work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196201010000-196212312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196201010000-196212312100.nc
+  hashes:
+    binhash: def9156f2641f39f29421ae8a8ac5562
+    md5: 9db4f080b3186d320184e57a0b2bb18b
+work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196301010000-196312312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196301010000-196312312100.nc
+  hashes:
+    binhash: c2bd9ed23b8e1f58dfc1911bc1e4abb8
+    md5: 26d4f8c91925a273e0a01aa42581125d
+work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196401010000-196412312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196401010000-196412312100.nc
+  hashes:
+    binhash: c9b7b83aee4b470b7d467b7067ad57f1
+    md5: 92e7158e5c02f2c101a6c8760836995e
+work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196501010000-196512312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196501010000-196512312100.nc
+  hashes:
+    binhash: 36c7ea235ea0dcf70626e448b0729a78
+    md5: 6fa10d1d68bf06128fe3d2a351a49210
+work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196601010000-196612312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196601010000-196612312100.nc
+  hashes:
+    binhash: f3fd691e7bb6f90f344b3dc4baa1deac
+    md5: 9ba0d4559df61875caf1b513285227e6
+work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196701010000-196712312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196701010000-196712312100.nc
+  hashes:
+    binhash: b25ef114742ef5f3ee0d84f8f4d02180
+    md5: 64cd0b8ff32402340dc207f1832681ac
+work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196801010000-196812312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196801010000-196812312100.nc
+  hashes:
+    binhash: a954b18eb3aff609fb82f5e4c9772234
+    md5: 5717b8212c8daad31cc2ec71b70088eb
+work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196901010000-196912312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196901010000-196912312100.nc
+  hashes:
+    binhash: 5825f1f933fa7f1bbc1257ef7a15e99b
+    md5: e3395e5b144a555dcbe6d64abfc9e1b6
+work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197001010000-197012312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197001010000-197012312100.nc
+  hashes:
+    binhash: ce1621e61cf468701da9fc4951b82745
+    md5: 213d2c2af67d35a05cb2497889bed8e0
+work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197101010000-197112312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197101010000-197112312100.nc
+  hashes:
+    binhash: a150e2e0f9fc4d29b1d4345ffe30c22a
+    md5: 5f319a78f3a931237a312f121fd4eeda
+work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197201010000-197212312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197201010000-197212312100.nc
+  hashes:
+    binhash: 52b7199e17c4d50cf746f4d050895fc9
+    md5: 5997ba3736b8f48148dc5cad0b386306
+work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197301010000-197312312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197301010000-197312312100.nc
+  hashes:
+    binhash: 18a14571dcc043d63d0c52be3d48a04c
+    md5: b0e3be6737557614dc88591026cff5a3
+work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197401010000-197412312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197401010000-197412312100.nc
+  hashes:
+    binhash: 612627a1b1a6c3989eb5d2c0ad1d5de6
+    md5: 80dbabdfec6f71847f107d96027b8e66
+work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197501010000-197512312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197501010000-197512312100.nc
+  hashes:
+    binhash: bb7be16c47452783944370d9e7b2cc86
+    md5: 2aae4f7d50121721af37c7c9b88722f4
+work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197601010000-197612312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197601010000-197612312100.nc
+  hashes:
+    binhash: b869c71a2370a33f4c7c0af136a6c391
+    md5: 268ef46c144be8542516ba9bee3505d1
+work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197701010000-197712312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197701010000-197712312100.nc
+  hashes:
+    binhash: 0445f151f3535064b8797433e278dbed
+    md5: 16daf0a5a6a15938ca1244d647a5035c
+work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197801010000-197812312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197801010000-197812312100.nc
+  hashes:
+    binhash: d166642e43d99ba2996821c59667027e
+    md5: b002956661c2ef02b66872e48ebe0860
+work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197901010000-197912312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197901010000-197912312100.nc
+  hashes:
+    binhash: 14bff64e9032151750b6065cdb2f68ec
+    md5: 3e84bcfd7f09ba89c9ceee77d15a6642
+work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198001010000-198012312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198001010000-198012312100.nc
+  hashes:
+    binhash: 595148dbd69cfa6d22e8ed953e9e2c39
+    md5: bf369d37b212bfbf828a7f98257a9a53
+work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198101010000-198112312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198101010000-198112312100.nc
+  hashes:
+    binhash: d7aa7c0dc45f2f6ea9554b0757415b37
+    md5: e6e42ed8f5310c39f49b1503148838a6
+work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198201010000-198212312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198201010000-198212312100.nc
+  hashes:
+    binhash: 91363a2bf8cf1b008ef410d996ac0d7f
+    md5: 34e796c84e40810f67d877c3592950f1
+work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198301010000-198312312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198301010000-198312312100.nc
+  hashes:
+    binhash: 7352918f1876d700ae8fb0f9c3fb3d7d
+    md5: 1f40589e425e794c66d3b232aa14dd66
+work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198401010000-198412312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198401010000-198412312100.nc
+  hashes:
+    binhash: 33e1b789673fd54a254a8fe60261c055
+    md5: d14d49762ccc4ce2717b357277203705
+work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198501010000-198512312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198501010000-198512312100.nc
+  hashes:
+    binhash: 8980a193782b65b734f193edf089fce8
+    md5: 737b589b34877530ff829acbe2237842
+work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198601010000-198612312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198601010000-198612312100.nc
+  hashes:
+    binhash: 92672910a1d18b5ff2a2ead9e1d1adf2
+    md5: 3cba1b517073ba2fb3485993cd251d21
+work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198701010000-198712312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198701010000-198712312100.nc
+  hashes:
+    binhash: c8aae9504349e47a6997cc62087c1cdc
+    md5: 0123317518d991e22b3bbed6322a7ec3
+work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198801010000-198812312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198801010000-198812312100.nc
+  hashes:
+    binhash: cfc0cdc586ff596c19b2a5f2fb2e4626
+    md5: 88dd309c2f89bf9023849cfb016de097
+work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198901010000-198912312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198901010000-198912312100.nc
+  hashes:
+    binhash: 6f78eb2eec777fccb0988cb43458f021
+    md5: 9a815dfbfa618d37fbe23365fb9e8ab3
+work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199001010000-199012312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199001010000-199012312100.nc
+  hashes:
+    binhash: d51574619b83fa331295f02b8b50bc8a
+    md5: d62b6769cebca26865a3931b0f58faa9
+work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199101010000-199112312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199101010000-199112312100.nc
+  hashes:
+    binhash: 863b21cca6b7b9950c1c0bc4e348d2bb
+    md5: 9ed502bf6faf7d475411e754d55fcfcc
+work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199201010000-199212312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199201010000-199212312100.nc
+  hashes:
+    binhash: e23c493ed5ce97880d74eb78525425ae
+    md5: d6f9c923243860a4e1e97ddf8c0dc568
+work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199301010000-199312312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199301010000-199312312100.nc
+  hashes:
+    binhash: c3a504616f2ea1f5f0007f2009fc9398
+    md5: 63e3b81a13125df5f4d2ed955f32e4a0
+work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199401010000-199412312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199401010000-199412312100.nc
+  hashes:
+    binhash: 02e00ece277413cca482a88fb4dda6bc
+    md5: 9b79cb78f3d5b914b867f328c8ba1d60
+work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199501010000-199512312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199501010000-199512312100.nc
+  hashes:
+    binhash: c73717690fada70a021ff192264b3621
+    md5: ee59eb1a12999b4b74958fa2bd56d380
+work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199601010000-199612312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199601010000-199612312100.nc
+  hashes:
+    binhash: 8a3afc73c48d68af18cb245e3ec211ff
+    md5: 18c1de4ab3aa0909441959036d81d823
+work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199701010000-199712312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199701010000-199712312100.nc
+  hashes:
+    binhash: a5d215ecfba3fdd2d695a1a08fb607a0
+    md5: 2c2875a130e66398c5c62a95bbb90b5c
+work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199801010000-199812312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199801010000-199812312100.nc
+  hashes:
+    binhash: 6feee8641216f714fa4827ca418ede0e
+    md5: 506284d5591d6eb5a654dfedbc7d3743
+work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199901010000-199912312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199901010000-199912312100.nc
+  hashes:
+    binhash: 6f2f7339768223ddaa1319400a0ce841
+    md5: 0a7eeab21547aa83a0963ee067b52289
+work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200001010000-200012312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200001010000-200012312100.nc
+  hashes:
+    binhash: d701166aeff7d443a6bf922877977f6e
+    md5: f596a9c1f3df2c44cc40e0cd6f726d9a
+work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200101010000-200112312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200101010000-200112312100.nc
+  hashes:
+    binhash: 4595c78cd8b9948368dfb497ca5cafdb
+    md5: f4a9fb51953e03c67da74cd32a39680f
+work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200201010000-200212312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200201010000-200212312100.nc
+  hashes:
+    binhash: ad1c1415e15cb1a24ee97be5b8e437c3
+    md5: debbe0399e98b7f2acf69954042fa3a2
+work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200301010000-200312312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200301010000-200312312100.nc
+  hashes:
+    binhash: 1f98bc9a70be947c39a3e45cbf2012a2
+    md5: 6cae563c4c7aa728159b6a3838437349
+work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200401010000-200412312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200401010000-200412312100.nc
+  hashes:
+    binhash: 5c26df7ee120f9fe3077d25d3e61a358
+    md5: 8e60292fd3953b82146d9a6fa59f5737
+work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200501010000-200512312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200501010000-200512312100.nc
+  hashes:
+    binhash: 76d4207ca8e1f4c203ff368ddf0bb99c
+    md5: 084fec6ad7757f43881beedc967c3292
+work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200601010000-200612312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200601010000-200612312100.nc
+  hashes:
+    binhash: 244f250ea2e0e228ee8373c621769e77
+    md5: f23c7bbbc061b4f116a4697ea6a423c6
+work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200701010000-200712312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200701010000-200712312100.nc
+  hashes:
+    binhash: a83f08eb12b640452903e90a6d4a8888
+    md5: 99e44527cef610f2b1193d4975051633
+work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200801010000-200812312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200801010000-200812312100.nc
+  hashes:
+    binhash: 85934960eb949b60e7512c2d08822d4c
+    md5: d988aada9f7c8847bffcc8f7f1a92b1f
+work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200901010000-200912312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200901010000-200912312100.nc
+  hashes:
+    binhash: 74c6a1378b792611b4fe6abc2c97388f
+    md5: b15626ca98b6a46c1deaaf615476575d
+work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201001010000-201012312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201001010000-201012312100.nc
+  hashes:
+    binhash: 4178714a58d1c1f4c4842409199073da
+    md5: 1608cd987dbeda7471d8e6684911bf04
+work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201101010000-201112312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201101010000-201112312100.nc
+  hashes:
+    binhash: 320b28d02c8435b26f92da74ca08484b
+    md5: 4e1d72f3bc7f65cffc9240a494a3e9a0
+work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201201010000-201212312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201201010000-201212312100.nc
+  hashes:
+    binhash: 48103d79f36e2fc48b97d696ec4e3b22
+    md5: d190a1c9ea13759a7fbbbbd3635b28ef
+work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201301010000-201312312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201301010000-201312312100.nc
+  hashes:
+    binhash: 23945daf613e17100db518e1cb4cb5f1
+    md5: 220b7a8803d06cf8beeda159b421412c
+work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201401010000-201412312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201401010000-201412312100.nc
+  hashes:
+    binhash: 7c070402d56ddef9846e8e38d191a291
+    md5: 2259b44b3f19565ff47e7a17ec13520c
+work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201501010000-201512312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201501010000-201512312100.nc
+  hashes:
+    binhash: 3355dd187916f1b9eb5712b2d3d1fa0a
+    md5: f31656356ca0809a22b34585e1aab338
+work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201601010000-201612312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201601010000-201612312100.nc
+  hashes:
+    binhash: ebb7ac6e792473dd99843fd7c3e3131b
+    md5: 3fab3736113f8d7c6413b7e540e48123
+work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201701010000-201712312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201701010000-201712312100.nc
+  hashes:
+    binhash: 45628039899e11331b21de806b517ac2
+    md5: 2d5b8a4d1b758fa419e07ee692b3f57c
+work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201801010000-201812312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201801010000-201812312100.nc
+  hashes:
+    binhash: 726d6238dbbc01b203ae863d18db696d
+    md5: 49d1171a6c937ad069844dbb5074e22c
+work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201901010000-201912312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201901010000-201912312100.nc
+  hashes:
+    binhash: d88da56f042ec9381d73e0c4835b7658
+    md5: 0d2b9e087ec4495e9a7b1196b88b1127
+work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202001010000-202012312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202001010000-202012312100.nc
+  hashes:
+    binhash: 5d12933bb40ae9736ab10105418763d7
+    md5: 46636298b7cd06398583f024b024e9db
+work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202101010000-202112312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202101010000-202112312100.nc
+  hashes:
+    binhash: 239e5ab4c0c617bbdb261b7662c6f3a3
+    md5: d77af41bbabab0c22df78a9b1a7ae1c5
+work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202201010000-202212312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202201010000-202212312100.nc
+  hashes:
+    binhash: cb12bdb1807ab8fb1d48dc847b532360
+    md5: 1d27e656c6ca871c26f3e9398ab8d5b3
+work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202301010000-202312312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202301010000-202312312100.nc
+  hashes:
+    binhash: 93a4571ee87a1c8f0f78794728d34f98
+    md5: b03a18fe229520879a9f9011cf1a0ebb
+work/atmosphere/INPUT/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202401010000-202402012100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/huss/gr/v20240531/huss_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202401010000-202402012100.nc
+  hashes:
+    binhash: 522f9795027469203f294d18b9bd7417
+    md5: 977dd1c63a2ee8025b74bf3c8ccc641b
+work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19580101-19581231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19580101-19581231.nc
+  hashes:
+    binhash: 3d2f602f66e5f366d5e0f8980ee2a3e3
+    md5: 4dc7d66abe1bb1f8cbe9301100d47e09
+work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19590101-19591231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19590101-19591231.nc
+  hashes:
+    binhash: b09f7d4b3890f1b64548d0f8d0493aa9
+    md5: ef6c29b1c42eb9eeba755cef03923bb7
+work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19600101-19601231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19600101-19601231.nc
+  hashes:
+    binhash: 37f8c924f9bd433b7309a5fb777a1812
+    md5: ead76adc866afa78edc172041ccb7f53
+work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19610101-19611231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19610101-19611231.nc
+  hashes:
+    binhash: f63dbd581c1c60b8f7a99beda467aeda
+    md5: 4309e03e96f4c184c25bc584579657ad
+work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19620101-19621231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19620101-19621231.nc
+  hashes:
+    binhash: 53d0f339046f08b99d68b379e35d269c
+    md5: 949f88cc21b8ec18c965ddcb1a50048d
+work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19630101-19631231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19630101-19631231.nc
+  hashes:
+    binhash: f5afc9e0b5d325b37e4a93e8fa77b560
+    md5: e1882f4c4444c26ed040d0590983230b
+work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19640101-19641231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19640101-19641231.nc
+  hashes:
+    binhash: ab1e1a28a995fe9db249cd182d7dcd4b
+    md5: 37ba3fa577bd11f18a8ca6aed14bd275
+work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19650101-19651231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19650101-19651231.nc
+  hashes:
+    binhash: 4a9ade23343febc3e8abd52ea5181ce7
+    md5: 7696eda1c119be64ed2349e63953850b
+work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19660101-19661231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19660101-19661231.nc
+  hashes:
+    binhash: 2949ced314e91db920cd19304dccbbf3
+    md5: 618713484243b828971b5efead938d72
+work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19670101-19671231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19670101-19671231.nc
+  hashes:
+    binhash: a1d0f28d4b9af1d51cd7cd3e9416c938
+    md5: 991262a3fadd4c3331019999afc910cc
+work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19680101-19681231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19680101-19681231.nc
+  hashes:
+    binhash: 6a6a98599f5887445bab418ff89e20a0
+    md5: 11520945d84580287b34c6c453027dc8
+work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19690101-19691231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19690101-19691231.nc
+  hashes:
+    binhash: b59a58abbf3a7ddba34c4952b0082500
+    md5: 11378aa7480ae662ebcc72e891f15107
+work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19700101-19701231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19700101-19701231.nc
+  hashes:
+    binhash: ba42a26d4f4dbcc77febc42703febee0
+    md5: a691b25130d888c4191e3cc573089b48
+work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19710101-19711231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19710101-19711231.nc
+  hashes:
+    binhash: f46cdf5df6bd6e13f350f95edccb2c3d
+    md5: 2eaa1f663a01213674919372771f5f91
+work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19720101-19721231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19720101-19721231.nc
+  hashes:
+    binhash: 1719d548c9838caca2e626aa6b79ab31
+    md5: 4948a6bd421ab9d13d0d68abfbf42ea3
+work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19730101-19731231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19730101-19731231.nc
+  hashes:
+    binhash: 610afaf90e25215c4749fcb61e08e8c2
+    md5: 262241ce28637e834df194fff097e621
+work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19740101-19741231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19740101-19741231.nc
+  hashes:
+    binhash: dc8b6c0b9d5a2294974c64eaaf1f0eb0
+    md5: c7360d077deb3289a6bbda33f328bf59
+work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19750101-19751231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19750101-19751231.nc
+  hashes:
+    binhash: 0066c783b6fe0233764a51aa0b4ef8f7
+    md5: 70a12bf571c3a9890a6432e37f60d421
+work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19760101-19761231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19760101-19761231.nc
+  hashes:
+    binhash: b786e6d4e0ea3ed99a0dd7170c1d30b2
+    md5: 9f911c28e2a58a9aeb8f3883f71c82fa
+work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19770101-19771231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19770101-19771231.nc
+  hashes:
+    binhash: c77defd7015ad2c86a508b00dfcfe6aa
+    md5: 87f95f38992f6adb23a17edb7775fc6f
+work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19780101-19781231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19780101-19781231.nc
+  hashes:
+    binhash: 521d5d273b27912d193f158fc062700a
+    md5: b8d806c1aaa0a2f298c54d97bce088a0
+work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19790101-19791231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19790101-19791231.nc
+  hashes:
+    binhash: 0ab56c2dc2b452afe79953e08020f9a7
+    md5: 9c6463e538f4adad7fb393f7eaddf505
+work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19800101-19801231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19800101-19801231.nc
+  hashes:
+    binhash: 494304742ce06ee928caf943d1229b19
+    md5: 3d033471fdf66c3bc1164a39ae84ea66
+work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19810101-19811231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19810101-19811231.nc
+  hashes:
+    binhash: c61cfa8774ba511158a812d06175c2d1
+    md5: 3ba3e7c06e4ea4871ed41cb3f5122003
+work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19820101-19821231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19820101-19821231.nc
+  hashes:
+    binhash: fb993af2958444d0ee83cd4dc2844abf
+    md5: 3c0d02d5d5af9434473425459e3a9e2e
+work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19830101-19831231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19830101-19831231.nc
+  hashes:
+    binhash: 3cd544754192423bf646fc779403239d
+    md5: e42b5ed7ea52e4a6e997145ebd82620e
+work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19840101-19841231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19840101-19841231.nc
+  hashes:
+    binhash: 578d7a69ff6595d8c30090210c21b743
+    md5: f1340c110cefb3b11aefd503b17e987d
+work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19850101-19851231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19850101-19851231.nc
+  hashes:
+    binhash: 6cd6a9724e8fe187204399170a38e2b1
+    md5: 84a526356b0837800b659c6c0fdb6e79
+work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19860101-19861231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19860101-19861231.nc
+  hashes:
+    binhash: 92b2e801e9de32ba87fa768b6e58d85b
+    md5: 8f5b81c2569e07abeb05a189c3b55528
+work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19870101-19871231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19870101-19871231.nc
+  hashes:
+    binhash: 0149eb20d88e0b20e37bd149042f6a84
+    md5: 9c22880ac52384494f8072bddd024bd8
+work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19880101-19881231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19880101-19881231.nc
+  hashes:
+    binhash: 3baa3b2b023492ad5939f72a012bfab5
+    md5: c33144d8d2fde4ecad399b6893263f5e
+work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19890101-19891231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19890101-19891231.nc
+  hashes:
+    binhash: c42c92e8c0f7a3e5c7beb404cb7c91d2
+    md5: a54abf8890bd4a734e110088007b9ff7
+work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19900101-19901231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19900101-19901231.nc
+  hashes:
+    binhash: 63172c1fb15b71d194322bb71e23f2a7
+    md5: fa274e99797cad7ac94b1b1f044c85be
+work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19910101-19911231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19910101-19911231.nc
+  hashes:
+    binhash: 953688ab0af8820d1d23b6228770a45c
+    md5: 79a247c0732980b78bb25f78c2932ae9
+work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19920101-19921231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19920101-19921231.nc
+  hashes:
+    binhash: 80071f967cabaabd1565bbccec926738
+    md5: 751d0534d4e4437afcff8a9ed4787bc8
+work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19930101-19931231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19930101-19931231.nc
+  hashes:
+    binhash: 4a251dec509abc976efa3355829df98e
+    md5: 4a0b5faa0430b381b1bcfe23e808f01b
+work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19940101-19941231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19940101-19941231.nc
+  hashes:
+    binhash: 79efbdc0d32087b753d8f26d8ef38158
+    md5: 824da7780820129e11feee2755ed81a2
+work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19950101-19951231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19950101-19951231.nc
+  hashes:
+    binhash: d51ee99465471468bb61173d26d685a9
+    md5: 6186eb91373a2f00b70d50d6fab15cc3
+work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19960101-19961231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19960101-19961231.nc
+  hashes:
+    binhash: c053b6467ddc15140deb1be29c7e3afb
+    md5: 1e97eae27e5a262956d0244f1aa9a57b
+work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19970101-19971231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19970101-19971231.nc
+  hashes:
+    binhash: d346ab54b4b215fe00cba3584ac0ce8f
+    md5: 8bc555c8bb7d9f69b9d5e78af4988d3f
+work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19980101-19981231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19980101-19981231.nc
+  hashes:
+    binhash: 18bc43fe241d8bd60645fab08d32d1a3
+    md5: 4855d36371ff5466bc7d08a57ba592e2
+work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19990101-19991231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_19990101-19991231.nc
+  hashes:
+    binhash: 7a8095d1f8f1ab16e0d08f7db9e3fa6b
+    md5: c540bad816651e1566cb6197230cab4f
+work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20000101-20001231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20000101-20001231.nc
+  hashes:
+    binhash: 25031feaae9fec1a4782a31cfb02b90f
+    md5: 58513ec92805224a55ee840d3bce1644
+work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20010101-20011231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20010101-20011231.nc
+  hashes:
+    binhash: e41f78ab3e4a4bbc4d32a6e1a7b91872
+    md5: 86e42100543c2ee687c6dac63563dcba
+work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20020101-20021231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20020101-20021231.nc
+  hashes:
+    binhash: 7752b31f9822629f4b58b5e09481c3a2
+    md5: 66553cbbfb345ca512e0f76aef301762
+work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20030101-20031231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20030101-20031231.nc
+  hashes:
+    binhash: ffc95c777da24ef8f7eb6c0bd9f3452c
+    md5: febe7f989dcd6c7c5136801f0bfdb8e5
+work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20040101-20041231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20040101-20041231.nc
+  hashes:
+    binhash: 5c58d8f704edbdf732c8ccf5e0a4bade
+    md5: 36dc16f09dc1d10ef9cd57609264c578
+work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20050101-20051231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20050101-20051231.nc
+  hashes:
+    binhash: 06bb2f15304c8aee790550cb389e9f3a
+    md5: c193f2e240f54c29cd5eeedae6fde425
+work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20060101-20061231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20060101-20061231.nc
+  hashes:
+    binhash: 8629650e466ff1ebc074762acdd127bf
+    md5: 459ca1df6daeefb0f071355144ad762c
+work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20070101-20071231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20070101-20071231.nc
+  hashes:
+    binhash: 5299f07cf53e30ee1035c013a8902542
+    md5: b3446ee947bc833778b95b81abbffda7
+work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20080101-20081231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20080101-20081231.nc
+  hashes:
+    binhash: 11cf7d6aaba48bf3f12e4b2e113f6810
+    md5: 4eaf87dac1e73ad4d3e05c4e29184fbd
+work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20090101-20091231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20090101-20091231.nc
+  hashes:
+    binhash: b86a3d370423b648bdd9553a920324e1
+    md5: 7442407571b1aeb82827663e377ae45e
+work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20100101-20101231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20100101-20101231.nc
+  hashes:
+    binhash: dd21df955dcfc5bde7a6a03534c47b4a
+    md5: 0947090925bedb50375606d9b8138c6f
+work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20110101-20111231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20110101-20111231.nc
+  hashes:
+    binhash: 999b0c61b6e381fe96440ad6705e3e20
+    md5: b81e8c8204e2f1e91ac34b121fc659f9
+work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20120101-20121231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20120101-20121231.nc
+  hashes:
+    binhash: 73360dccbc5e7f79d0d7229f0ba20234
+    md5: d57c21d3f153a9618796ba4bcb263bd5
+work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20130101-20131231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20130101-20131231.nc
+  hashes:
+    binhash: 021cecf75afa3164f15b016d25cb14b4
+    md5: 397fb3040a92caf2f6169edb2a6d3350
+work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20140101-20141231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20140101-20141231.nc
+  hashes:
+    binhash: 304a2e613ade54d2db02697c47941aa2
+    md5: 854740c817bd605cee1c52a8d87dd1b8
+work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20150101-20151231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20150101-20151231.nc
+  hashes:
+    binhash: 3639be7ab746a4bb16d586dcd9b8a30c
+    md5: d97fab3626a06ffced1e85df7bb06b4c
+work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20160101-20161231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20160101-20161231.nc
+  hashes:
+    binhash: a2354cdd540dc9ce0df90b3e955c4073
+    md5: db665582428f9e16bf66f1189dd086a6
+work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20170101-20171231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20170101-20171231.nc
+  hashes:
+    binhash: 0bcb105d2d82ec40f807a298c1fd1340
+    md5: 2969641a7c4e75452e8820d3266dbfda
+work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20180101-20181231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20180101-20181231.nc
+  hashes:
+    binhash: 11fd8448b57747230082b358aeda12e4
+    md5: aa7bed901af9372045192363c90c993d
+work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20190101-20191231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20190101-20191231.nc
+  hashes:
+    binhash: ddf7dd5503d7010f7bacce591db0fa4e
+    md5: 18e53f41ace0a315b809effdc99d22d4
+work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20200101-20201231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20200101-20201231.nc
+  hashes:
+    binhash: 9987611bd642d14701f1d6154d9b0d06
+    md5: 06c9bc0211baa8b7b4f1abbaac3292d6
+work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20210101-20211231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20210101-20211231.nc
+  hashes:
+    binhash: dcf8bf5bff72fa25fdacdac0208e92a2
+    md5: b321ed9aebef790e77e00f4551db718e
+work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20220101-20221231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20220101-20221231.nc
+  hashes:
+    binhash: e7163e400052c11f94d49ca936f7e579
+    md5: 2b358d09bd5f33aa816aaa50555c37d1
+work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20230101-20231231.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20230101-20231231.nc
+  hashes:
+    binhash: 4ee9bd27c9eefe94a6e46a7632647ec7
+    md5: 51f76e78319b3170bffde092f935bbaa
+work/atmosphere/INPUT/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20240101-20240201.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/landIce/day/licalvf/gr/v20240531/licalvf_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_20240101-20240201.nc
+  hashes:
+    binhash: fb4da82e21b01ccd4ef5e7a99f31f4e5
+    md5: 6838f869a96238b2b162103794739519
+work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_195801010130-195812312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_195801010130-195812312230.nc
+  hashes:
+    binhash: a647064fc4f886b999a83b6a205180fd
+    md5: 570ef5d99e13d89211bdb86fa70b4eed
+work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_195901010130-195912312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_195901010130-195912312230.nc
+  hashes:
+    binhash: 0acd96fd1dfc2fb59c072d916eed1f35
+    md5: ec79e6862c332edb3c0831b575b3f4b8
+work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196001010130-196012312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196001010130-196012312230.nc
+  hashes:
+    binhash: cbff4729315c0dff2aae7287966257cf
+    md5: 097bd2e28e571762b910026c39baf126
+work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196101010130-196112312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196101010130-196112312230.nc
+  hashes:
+    binhash: 69cb8558dba1614284a4735e998c4c8e
+    md5: 1c200bcbfb7367da227ee9aaa18f5b53
+work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196201010130-196212312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196201010130-196212312230.nc
+  hashes:
+    binhash: 2ccd8497594a9451d8aa676c13c83152
+    md5: e3a91fc0876ad065e4a458b2ab0ffb2b
+work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196301010130-196312312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196301010130-196312312230.nc
+  hashes:
+    binhash: d01bd3c22a041529f6581f1ffe562bff
+    md5: 6bb1d6ac1fa0ccfe56553b6d8a41b6e6
+work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196401010130-196412312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196401010130-196412312230.nc
+  hashes:
+    binhash: 9bfa5b31a525a93ff37b732a8d981a7b
+    md5: 707f52e527d4632d083ef8b2fc914145
+work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196501010130-196512312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196501010130-196512312230.nc
+  hashes:
+    binhash: ad1b2eaee263fbfc8646f7f82233adc3
+    md5: ec3ae945694c8c8294fb9fc579aef1e6
+work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196601010130-196612312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196601010130-196612312230.nc
+  hashes:
+    binhash: e0d6f66b6d58054102050f422d6d2d18
+    md5: cb2922838fb3469dff4d69d8127ada5a
+work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196701010130-196712312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196701010130-196712312230.nc
+  hashes:
+    binhash: acfd1241c6fadd74d1894d918aacb4b1
+    md5: 813cfb7d6cee8196452d63b837a3d8d6
+work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196801010130-196812312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196801010130-196812312230.nc
+  hashes:
+    binhash: 41ed06ffd5a805431c4338491ee9659f
+    md5: 9e4db5f9486dbb600a9baed17984a7c9
+work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196901010130-196912312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196901010130-196912312230.nc
+  hashes:
+    binhash: 43098110cdb798a3f9e9a64e27476ea9
+    md5: 398a6e54c79f71b29d297d488069c90f
+work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197001010130-197012312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197001010130-197012312230.nc
+  hashes:
+    binhash: c2fd97a9604d7348e6b26b18eb348ce7
+    md5: 65fd7154fa2462b2469acabcd91c0d10
+work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197101010130-197112312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197101010130-197112312230.nc
+  hashes:
+    binhash: 7947b8a72a44e2f12a9cd2866c954552
+    md5: 6e89f1877ba86a5a61ab40c60a25f0fc
+work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197201010130-197212312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197201010130-197212312230.nc
+  hashes:
+    binhash: 6d87c5a8118275ef63dbec7e2827a7a3
+    md5: ea2bbfbd6a9cc17769e003e5e75d4d6a
+work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197301010130-197312312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197301010130-197312312230.nc
+  hashes:
+    binhash: 0a25ea18ee1d23746c240363eb0655c7
+    md5: 83fc0e7bc0bf8e57a7cf19b6f02755eb
+work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197401010130-197412312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197401010130-197412312230.nc
+  hashes:
+    binhash: 3adb4b52b08dfd123a41cebf1d195149
+    md5: f440700f0ad58f8a0f4b1a3ec8914585
+work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197501010130-197512312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197501010130-197512312230.nc
+  hashes:
+    binhash: ff9e56af58a297e857712af94531c686
+    md5: 61899b19d2a0b3afbafb7c40ea631221
+work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197601010130-197612312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197601010130-197612312230.nc
+  hashes:
+    binhash: 4455e8b215a490b35998b9187e14e996
+    md5: 4545aacc7dc36107291543c0916337f8
+work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197701010130-197712312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197701010130-197712312230.nc
+  hashes:
+    binhash: e6b4ae04da2ee2e151ee66a68442c11c
+    md5: aa5da30f4069528c110c8f761dab38c2
+work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197801010130-197812312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197801010130-197812312230.nc
+  hashes:
+    binhash: f328e7ab792e22243bb720598659d8b9
+    md5: b07439eeb174b448f9288e6572211c91
+work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197901010130-197912312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197901010130-197912312230.nc
+  hashes:
+    binhash: c35a3038bb2ca82aed249440ed832798
+    md5: 193b1dcb4eabdd28a7686296c5cb9dc4
+work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198001010130-198012312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198001010130-198012312230.nc
+  hashes:
+    binhash: 7f0e78268c8eeb3ccdf007d96362410c
+    md5: df2610cd2ac956eaf24d68b5a52b13ba
+work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198101010130-198112312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198101010130-198112312230.nc
+  hashes:
+    binhash: 2628cbe9db8d344a4a6ab0a34a129fb8
+    md5: ff773d31036e801823d327810009e5ea
+work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198201010130-198212312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198201010130-198212312230.nc
+  hashes:
+    binhash: e0c4ec12c56b23c15c4f2c4e134b5e45
+    md5: 57bfa9f14b2a4d4e3e29b0c880f3bf6d
+work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198301010130-198312312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198301010130-198312312230.nc
+  hashes:
+    binhash: e33735ae9b2079c103db0b3b772b0503
+    md5: 8b188fb0268e85bea80e1379560992c6
+work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198401010130-198412312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198401010130-198412312230.nc
+  hashes:
+    binhash: d126d81b9afd712c8f816a1e8dafd046
+    md5: 192b328aee99583874cec378093d26ad
+work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198501010130-198512312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198501010130-198512312230.nc
+  hashes:
+    binhash: e5e722d388cefb9e0ac5814e88cab42d
+    md5: f8faac968118902fa6f22a313afe77e0
+work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198601010130-198612312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198601010130-198612312230.nc
+  hashes:
+    binhash: 12d5977a4e6286e2a00d55edf4e1b49a
+    md5: a35d2dcb3b3b8b4c4d99236bc0827164
+work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198701010130-198712312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198701010130-198712312230.nc
+  hashes:
+    binhash: 667908e21699c9d237bec47e1d4a6688
+    md5: aae66fa0f9c77faa1e714ff9ec4eec5e
+work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198801010130-198812312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198801010130-198812312230.nc
+  hashes:
+    binhash: e42796fb38460f5f2104f13723f8d269
+    md5: a91051feca5bd120e6e157cebdab7df7
+work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198901010130-198912312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198901010130-198912312230.nc
+  hashes:
+    binhash: c4e46ffb2d63d206fd978dea12549e06
+    md5: a291cbc095671f988beb10b1aefbe61c
+work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199001010130-199012312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199001010130-199012312230.nc
+  hashes:
+    binhash: cc5104db05346f4a5b00bde2d300e90d
+    md5: fdc8e6b8b1160d215ae9e10fef9a623d
+work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199101010130-199112312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199101010130-199112312230.nc
+  hashes:
+    binhash: 794d826f1d188b5b319e1857b83dfc11
+    md5: 7399d01db1d0ba7fed1e28cf49f37850
+work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199201010130-199212312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199201010130-199212312230.nc
+  hashes:
+    binhash: 301258730e570deddec32aef622b575c
+    md5: 55775972da7c38d6b59560f9a7342c3f
+work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199301010130-199312312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199301010130-199312312230.nc
+  hashes:
+    binhash: 71ffeb78c1fad4a04f8071212a2e90c6
+    md5: e306f754ca7338297650c614a5db97f1
+work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199401010130-199412312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199401010130-199412312230.nc
+  hashes:
+    binhash: 3525ebcf3b7692accc13fe37b51d78be
+    md5: 9b115255f8f37729b2fe01fb5e25028a
+work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199501010130-199512312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199501010130-199512312230.nc
+  hashes:
+    binhash: 40ab78887bcd62c8fb6c4f3c0a94a485
+    md5: b59191b601207813aaadafc8052b44ca
+work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199601010130-199612312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199601010130-199612312230.nc
+  hashes:
+    binhash: 702f4975e2378c49bacb824522a0133e
+    md5: 7ae7fbdc1a49b91459b42df9741ad266
+work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199701010130-199712312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199701010130-199712312230.nc
+  hashes:
+    binhash: c360f67d9a99660dcb155d7e4cf4eec0
+    md5: 56c45b8413e02b84af02df95b2e09d65
+work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199801010130-199812312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199801010130-199812312230.nc
+  hashes:
+    binhash: 8e6c8ad2db735b3a03fbfcfba5d4535d
+    md5: 31dd717d86dc26ffe6e90d155e721569
+work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199901010130-199912312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199901010130-199912312230.nc
+  hashes:
+    binhash: c61eed3cfe91c91382dda95d7a659e94
+    md5: 7251564806635bd128f282a5268ccc12
+work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200001010130-200012312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200001010130-200012312230.nc
+  hashes:
+    binhash: 96f1745fffdc117b66acc844c6a16ed9
+    md5: 8928e22ddd567dda16e5d6784f4e6998
+work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200101010130-200112312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200101010130-200112312230.nc
+  hashes:
+    binhash: 571836375b50b43e6a7e8a56a563e040
+    md5: d2227a9a603ad390b3b1407daebb2e57
+work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200201010130-200212312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200201010130-200212312230.nc
+  hashes:
+    binhash: d6163b3d48fbb6c28aae3007752a3950
+    md5: 258bc4d3bd5938d6afac30f0959040b0
+work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200301010130-200312312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200301010130-200312312230.nc
+  hashes:
+    binhash: f0e609d5198d77e0323deec41bf40d2e
+    md5: 055c37244be4b823649e3e9cf9199440
+work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200401010130-200412312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200401010130-200412312230.nc
+  hashes:
+    binhash: 550cd48e449077602846f0ae4f082847
+    md5: d49a29e78b400e65f053b1c858fa7536
+work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200501010130-200512312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200501010130-200512312230.nc
+  hashes:
+    binhash: b88099596ee923e2a875dd23d2f3e52b
+    md5: 1a365469e87e09dc57d1b60b7fa515fb
+work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200601010130-200612312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200601010130-200612312230.nc
+  hashes:
+    binhash: 4b486410f585ac616d9f67b27d3cc3af
+    md5: 2a875a7ac3e0a6a541698ac18644255a
+work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200701010130-200712312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200701010130-200712312230.nc
+  hashes:
+    binhash: 3986038b10ecd44532f6b2dc265ca44e
+    md5: e1ba9e320b504bcd8bbbedecaf6cf17a
+work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200801010130-200812312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200801010130-200812312230.nc
+  hashes:
+    binhash: 2dc80979ed7a1ab565756db725244440
+    md5: 443bd23dffc028705425f9bc9645654b
+work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200901010130-200912312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200901010130-200912312230.nc
+  hashes:
+    binhash: f49244762ce44d1030b8021606305f50
+    md5: 6687bec7c91fec382df9f3a7424d3286
+work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201001010130-201012312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201001010130-201012312230.nc
+  hashes:
+    binhash: 7e3c19913a2d3a8282c98e2b8675376c
+    md5: 752fc71733482df4092360d6baeca9af
+work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201101010130-201112312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201101010130-201112312230.nc
+  hashes:
+    binhash: d9d8c5ec7fe82fd9f42543e81b36018f
+    md5: 403453e5b19ae7a1ac37c2440f091fce
+work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201201010130-201212312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201201010130-201212312230.nc
+  hashes:
+    binhash: 5773e7ab558bfcd4c81eabec286c40e7
+    md5: 22a5aba9f7366ff5f026d2b6244d2dcd
+work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201301010130-201312312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201301010130-201312312230.nc
+  hashes:
+    binhash: ef7986f9e91d0bc02e713b8578385ab5
+    md5: e00ecd6108fdf4a62107fa7a51787865
+work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201401010130-201412312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201401010130-201412312230.nc
+  hashes:
+    binhash: df11803dd6dc911b557747a5f8c119f2
+    md5: 45bb68ba56f6be7aa61e755a5c2541ec
+work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201501010130-201512312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201501010130-201512312230.nc
+  hashes:
+    binhash: 880654df2760c3e083ad7d03571b81d2
+    md5: 0858adbf385da0c15a97d5ecb6b44c75
+work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201601010130-201612312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201601010130-201612312230.nc
+  hashes:
+    binhash: 19535348028765eb535016d12603177c
+    md5: 6c118c7d5aa68b83723486c36e02d69e
+work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201701010130-201712312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201701010130-201712312230.nc
+  hashes:
+    binhash: 479753050a790c78b082520ea1ef2da2
+    md5: fc7c8dca008c040808afbf43ee17ac32
+work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201801010130-201812312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201801010130-201812312230.nc
+  hashes:
+    binhash: daa2e767fb63c74a78e9170ddf530546
+    md5: 7bc60730c7c231445b502e291eb0cdac
+work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201901010130-201912312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201901010130-201912312230.nc
+  hashes:
+    binhash: c3c4ca4a8eed6402b6b95aa78df50b4f
+    md5: 582ea6f0d763a0af62f516b18fb594f7
+work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202001010130-202012312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202001010130-202012312230.nc
+  hashes:
+    binhash: 8c43bf6372945d568f47d51484cd827b
+    md5: 6e4de2ff5defbf6b3f100762e8604812
+work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202101010130-202112312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202101010130-202112312230.nc
+  hashes:
+    binhash: 1d1a6825de1529ac622cb3a3276ac4ed
+    md5: 7e9b3faf06a89f78127078b272bd6a25
+work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202201010130-202212312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202201010130-202212312230.nc
+  hashes:
+    binhash: d9092d720a1557a8a80a0412c3090d7b
+    md5: 6c1e781909f2de09e47f028d6cc2c63d
+work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202301010130-202312312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202301010130-202312312230.nc
+  hashes:
+    binhash: ae819bbcf49fdd5cb80d2ab617d4804f
+    md5: 1e6719ae70d8e688f5292cf89fc6c8c0
+work/atmosphere/INPUT/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202401010130-202402012230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prra/gr/v20240531/prra_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202401010130-202402012230.nc
+  hashes:
+    binhash: caf03f5d627c011928b6a1c5b8eb9577
+    md5: 5d4708de744d8e38c16e0c60a788c5ab
+work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_195801010130-195812312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_195801010130-195812312230.nc
+  hashes:
+    binhash: 05e905f8583228554deff28866f87268
+    md5: 72003ad67399d2ae94f447844e6f6596
+work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_195901010130-195912312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_195901010130-195912312230.nc
+  hashes:
+    binhash: 9b02e77ddadcbf86883c2f85ddb912ea
+    md5: aebcf740627799d8cd12c8beb55314ed
+work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196001010130-196012312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196001010130-196012312230.nc
+  hashes:
+    binhash: d04d2a71fdead9e0019d5fc5078c03cd
+    md5: 18e560b16c3ab927c18af21044aaeb70
+work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196101010130-196112312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196101010130-196112312230.nc
+  hashes:
+    binhash: 08054abc0cff75cda9b45c7421c379df
+    md5: 41ab4517d8997f47fd686585155ff096
+work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196201010130-196212312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196201010130-196212312230.nc
+  hashes:
+    binhash: 264c7f0f77fb1858654cae0fc9cc291f
+    md5: 4c9a22c0987ccec868f11aecea865ca1
+work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196301010130-196312312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196301010130-196312312230.nc
+  hashes:
+    binhash: 39bee2f22a2e14ed658239961dfb0604
+    md5: a645425415588c3a5f4613a9c249fc8b
+work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196401010130-196412312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196401010130-196412312230.nc
+  hashes:
+    binhash: 93f1472830dc72c83e82b453cd890417
+    md5: 2e6fe9de733497f2228506750dffd2a5
+work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196501010130-196512312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196501010130-196512312230.nc
+  hashes:
+    binhash: 8608da5bf23c82c2d619992f0094e4c2
+    md5: 8b96dc65d77de675f81070a6bcf0537b
+work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196601010130-196612312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196601010130-196612312230.nc
+  hashes:
+    binhash: 54418ccab32f7b34d66e6eb99dda52da
+    md5: 8ac9a1a78b8043bf4b11b29bf168d777
+work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196701010130-196712312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196701010130-196712312230.nc
+  hashes:
+    binhash: 062da543b3f982db44f3ef607aba6d3e
+    md5: bbd2764a85dadb6c63fac0f49e4bccd2
+work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196801010130-196812312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196801010130-196812312230.nc
+  hashes:
+    binhash: 177428e030e6885ce1ce273f512de37f
+    md5: ff8665c6c3f4feb232566ad686562c06
+work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196901010130-196912312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196901010130-196912312230.nc
+  hashes:
+    binhash: a1b200b3ef7149fa6c929cfbeadc073c
+    md5: f8b0ecf0a0387188fc2a48bbb9547e90
+work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197001010130-197012312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197001010130-197012312230.nc
+  hashes:
+    binhash: 4a7aaf94bd1ea95805947bc8a1c1f18a
+    md5: 4271560144fecaeab6381a68191d2c79
+work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197101010130-197112312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197101010130-197112312230.nc
+  hashes:
+    binhash: 992a0bc7007a8922c94a29bfb444a70f
+    md5: 5624f16a8d894ce94a11b21b05f7d021
+work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197201010130-197212312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197201010130-197212312230.nc
+  hashes:
+    binhash: 1b20fde3add7fa58d63802987ca28f68
+    md5: 66a2dc7c57b86609b0e7c4f36112bddc
+work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197301010130-197312312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197301010130-197312312230.nc
+  hashes:
+    binhash: 83f4b4ee32b3b56837887f4b001ab5b3
+    md5: b9697f0575e8ef471104d69fa5c2c32a
+work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197401010130-197412312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197401010130-197412312230.nc
+  hashes:
+    binhash: b386454c9cc51b3eb494c95da58f06ee
+    md5: f2f5310102ff7cc83a2eb51ad840891e
+work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197501010130-197512312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197501010130-197512312230.nc
+  hashes:
+    binhash: 93c3f23e000e450be02fb10959a6a3d9
+    md5: 0156c6900392d863a99dd7aafe347db8
+work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197601010130-197612312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197601010130-197612312230.nc
+  hashes:
+    binhash: 88dd7a31065c68064b61c65f8a0e214b
+    md5: 434146a9c5cbbe1922312ce091ef5d4c
+work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197701010130-197712312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197701010130-197712312230.nc
+  hashes:
+    binhash: b4b24eb5dd27486198e058401a40220e
+    md5: 6e31bd5f26e535f93697dc7124dfcd8b
+work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197801010130-197812312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197801010130-197812312230.nc
+  hashes:
+    binhash: ef35b97d1523a6f49e7f0415a7faf483
+    md5: 6e62742f8ce9b3b0c3e7c4a301fa2c84
+work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197901010130-197912312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197901010130-197912312230.nc
+  hashes:
+    binhash: 71f12074cd8849da934baa130c246e5d
+    md5: 68cdb7167eb3139d62dfdb8f200090fc
+work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198001010130-198012312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198001010130-198012312230.nc
+  hashes:
+    binhash: 20323b28330d6f2f21a634db4a1e1bf5
+    md5: 5e98731781564ccf2502ad7fe24e2972
+work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198101010130-198112312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198101010130-198112312230.nc
+  hashes:
+    binhash: 101ecc9fa6e28f6cb7f02ffc4dc289ab
+    md5: 6f2e153eb44db91c2be2a3348b3ac473
+work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198201010130-198212312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198201010130-198212312230.nc
+  hashes:
+    binhash: d37aa3c4f84418b938f738d150ae6462
+    md5: 979bb8c646b70906d49eedc273bc3dce
+work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198301010130-198312312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198301010130-198312312230.nc
+  hashes:
+    binhash: 475a1c3051ebb9c748b67e7f3c22c14b
+    md5: 3b07d277d0877fccc050306ec99225ba
+work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198401010130-198412312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198401010130-198412312230.nc
+  hashes:
+    binhash: 65780c22faa87114e3ad71caaacef1eb
+    md5: 28f04743dd845c839b67bccc5d04bb9c
+work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198501010130-198512312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198501010130-198512312230.nc
+  hashes:
+    binhash: 27514328ec804566bbc78037bdbeb403
+    md5: 0ae662d4faa535c7b676edb512349ec1
+work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198601010130-198612312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198601010130-198612312230.nc
+  hashes:
+    binhash: c6829be00b6a25cbb7fb8954959370b3
+    md5: 4bcf50a0c01a9b4ae81b42c21f05f84f
+work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198701010130-198712312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198701010130-198712312230.nc
+  hashes:
+    binhash: e61e2e76b1c9ff6c2bbb7a5840d69abf
+    md5: af4f75de3c79b54d817d6e262cbf7e52
+work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198801010130-198812312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198801010130-198812312230.nc
+  hashes:
+    binhash: 06846c4680f6dfb1d06f1f09e1c9229f
+    md5: 1e79440684c50c728950dbfec968ab69
+work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198901010130-198912312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198901010130-198912312230.nc
+  hashes:
+    binhash: 601ad833128670fba8c2c4e8b9232d0f
+    md5: 00a60563bd96b47a892da60fba1df7e4
+work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199001010130-199012312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199001010130-199012312230.nc
+  hashes:
+    binhash: 8f402669fc4bf9c445b71be0c042baeb
+    md5: d9cbf6e0a3a1a358ed8a6025a5861883
+work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199101010130-199112312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199101010130-199112312230.nc
+  hashes:
+    binhash: 65740da3d6e1ee9e0d58229a94ef39c1
+    md5: f3e4cf2a407b2aa1785312a80aa1dbc4
+work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199201010130-199212312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199201010130-199212312230.nc
+  hashes:
+    binhash: 8a36ae7553a040cad2060bd86c286f61
+    md5: e6d0ad356add2b77aac18e6ffda51c63
+work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199301010130-199312312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199301010130-199312312230.nc
+  hashes:
+    binhash: 14c66af4ea74295b6956381b5f6dabf5
+    md5: 3f5ed24bc7278ad20bc8c7b677ed2404
+work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199401010130-199412312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199401010130-199412312230.nc
+  hashes:
+    binhash: ee40d97df05623b9a483546d58ca77d6
+    md5: b3a08a80a26fed9e92745e7405d9a2a8
+work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199501010130-199512312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199501010130-199512312230.nc
+  hashes:
+    binhash: 345d5c9c4b407096d1c80a94dcc047a3
+    md5: 3190d69a522dd28860f15585abf1b870
+work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199601010130-199612312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199601010130-199612312230.nc
+  hashes:
+    binhash: a1ff02437272a6310179941e9a936e36
+    md5: fc29f78455755ed930714d9f70292452
+work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199701010130-199712312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199701010130-199712312230.nc
+  hashes:
+    binhash: 1f234526bb64e51ac57c2d3a95f0fc4c
+    md5: 8a7d392322784e6e3674809302fd61cf
+work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199801010130-199812312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199801010130-199812312230.nc
+  hashes:
+    binhash: 0edcd726170f22e41e2993d48657c4c2
+    md5: 48c6d0371f3158dbb4b19d601bcbe3e8
+work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199901010130-199912312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199901010130-199912312230.nc
+  hashes:
+    binhash: 1ed5d0dc718e406acf4378a9a72bef36
+    md5: 697302faf5df299731135adf5dbbfd0c
+work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200001010130-200012312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200001010130-200012312230.nc
+  hashes:
+    binhash: aff2d00e41d3dd2a820ea81baaf0b7fa
+    md5: 5f4432fc93288f8c45c9228c242a47af
+work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200101010130-200112312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200101010130-200112312230.nc
+  hashes:
+    binhash: 1a3bb146b0d49c7e04a0e80505e14023
+    md5: 66945024d9e203cf9cfe7b8f253225f5
+work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200201010130-200212312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200201010130-200212312230.nc
+  hashes:
+    binhash: 44973c98674b4f862b243f50cf6ed455
+    md5: d7439a83b276c06c53050b2e384cd75c
+work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200301010130-200312312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200301010130-200312312230.nc
+  hashes:
+    binhash: f9d00565c492aa465ab28c8eedf4a4ff
+    md5: 8f5d17584b86588730b50d58e223457f
+work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200401010130-200412312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200401010130-200412312230.nc
+  hashes:
+    binhash: 15a952156676bdc7c53cc27d20447eff
+    md5: 06df35ffd1379718b7e2a2ae1d2e2e7e
+work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200501010130-200512312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200501010130-200512312230.nc
+  hashes:
+    binhash: 510678f4a908e020194cd746ea969945
+    md5: ca7b9534de2fb9403e4f54c26c9ae812
+work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200601010130-200612312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200601010130-200612312230.nc
+  hashes:
+    binhash: 4cefca5beef024cf7b14b32507e5893e
+    md5: 7e7df2ce3598444681d8ecbcab29cf23
+work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200701010130-200712312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200701010130-200712312230.nc
+  hashes:
+    binhash: 26adb4e24d45cca41ffeae4e90e20373
+    md5: 01f4475a026c57628b60d4af05e7136d
+work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200801010130-200812312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200801010130-200812312230.nc
+  hashes:
+    binhash: d0382281dde2fc9229179705d5d0e47e
+    md5: 5cf7463493b252fcdcd2447a6e711522
+work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200901010130-200912312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200901010130-200912312230.nc
+  hashes:
+    binhash: 41bb721e75255e14f9613db31d7aabdf
+    md5: 86198ff9b1a38c91ff38a42357e2b14b
+work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201001010130-201012312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201001010130-201012312230.nc
+  hashes:
+    binhash: 85933da9d609f36014a9de09007045b7
+    md5: 615939f0ecccd9722feb9412388feeb6
+work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201101010130-201112312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201101010130-201112312230.nc
+  hashes:
+    binhash: ee303858d6a3971588ead8d5342b46b8
+    md5: 8fba988ab1a76dc3fd9c149ead3cc3ad
+work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201201010130-201212312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201201010130-201212312230.nc
+  hashes:
+    binhash: d3bc01ecc1d03683295d68fd7f20ebf9
+    md5: 1eec2b849587eb4c930246b1d89c9dfa
+work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201301010130-201312312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201301010130-201312312230.nc
+  hashes:
+    binhash: 7205940accb8c814e2674444c9ac115c
+    md5: 1eb8ed4f7cbca3f3ab418f4e9c7173dd
+work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201401010130-201412312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201401010130-201412312230.nc
+  hashes:
+    binhash: 925fd6cdef3f4a1df304b09a71ce6293
+    md5: 854f9bcfeead17413b3c7029c31cb6de
+work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201501010130-201512312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201501010130-201512312230.nc
+  hashes:
+    binhash: ff16d562c1b083b453f4da044a9058a9
+    md5: 88d9a7d78a0fc7bb99e29df072457024
+work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201601010130-201612312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201601010130-201612312230.nc
+  hashes:
+    binhash: 9624abe34e740ee96fa5ef1f948f0094
+    md5: a29f711f605c7c8f981fd85eb59db185
+work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201701010130-201712312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201701010130-201712312230.nc
+  hashes:
+    binhash: cb7e5fc6d1506a04f422a89ab44e0459
+    md5: 9440e385302d85637a18ebef2052832c
+work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201801010130-201812312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201801010130-201812312230.nc
+  hashes:
+    binhash: 05ca827fa94a3c7129c0fbd64617cd65
+    md5: b0a487fb36cfb4d479794106e37d399f
+work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201901010130-201912312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201901010130-201912312230.nc
+  hashes:
+    binhash: 26c90550cef0c39566fa43ffdca91498
+    md5: c65142c98855bfbb8aeaf43e0990854d
+work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202001010130-202012312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202001010130-202012312230.nc
+  hashes:
+    binhash: 64a52cba09f655765a095795b72947ee
+    md5: 604d66108399866e38ad0faff47140e2
+work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202101010130-202112312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202101010130-202112312230.nc
+  hashes:
+    binhash: 37cf2983da58e1245f1159e27e6c42b0
+    md5: 1602e113e4feeecaf5003cf4df53bb7f
+work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202201010130-202212312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202201010130-202212312230.nc
+  hashes:
+    binhash: 3c65e377db199084866a20467104a7ef
+    md5: 39757ac84c26572eab0b6c506d5532b3
+work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202301010130-202312312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202301010130-202312312230.nc
+  hashes:
+    binhash: b6a433a9f7a9645680882dfe7c6f52c0
+    md5: a61bb6b4b9f5bd70254df42395bd8422
+work/atmosphere/INPUT/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202401010130-202402012230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/prsn/gr/v20240531/prsn_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202401010130-202402012230.nc
+  hashes:
+    binhash: 1bee178ce557ea767aedc660d6e9713f
+    md5: 503c04c52c805b27778282c3589b318f
+work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_195801010000-195812312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_195801010000-195812312100.nc
+  hashes:
+    binhash: 1bce49b97496b4a994f5fdb57a6a155a
+    md5: 6d58245add11349d211dca2e487dd644
+work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_195901010000-195912312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_195901010000-195912312100.nc
+  hashes:
+    binhash: 0e38e3a7ffa12aa59adce2a1760690e4
+    md5: 211fb537f59a5fc747fe4455af948bde
+work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196001010000-196012312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196001010000-196012312100.nc
+  hashes:
+    binhash: d57b043a4c475e56f7315ba448773207
+    md5: 5f5074539c579b57a79f103bd31c752f
+work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196101010000-196112312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196101010000-196112312100.nc
+  hashes:
+    binhash: 1f570cc688b8d48d72e695301551de3c
+    md5: f83c4abcb6e97ae856e81924461e095e
+work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196201010000-196212312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196201010000-196212312100.nc
+  hashes:
+    binhash: 67967ffbfe653b6f9154c47ec8bad18b
+    md5: 0354c9be56b51c74b589b6c84a051c05
+work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196301010000-196312312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196301010000-196312312100.nc
+  hashes:
+    binhash: 186c8dc706cf873c9b39a8727afeaa6e
+    md5: 1755e64228681842d1d4800c070b7d34
+work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196401010000-196412312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196401010000-196412312100.nc
+  hashes:
+    binhash: 60bd88d3decbc2c74d507d6399156344
+    md5: 2e71ab68954ae74998375420d4c3c6a8
+work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196501010000-196512312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196501010000-196512312100.nc
+  hashes:
+    binhash: c6dc3a099ade352c4806837bd18fcfea
+    md5: 0fe1461c8fce03cd3d6fd640fae82e21
+work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196601010000-196612312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196601010000-196612312100.nc
+  hashes:
+    binhash: 17bfca0d4eef71eac523b388c666597f
+    md5: a2ff8572c2ca809b5260f20a9bef59b6
+work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196701010000-196712312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196701010000-196712312100.nc
+  hashes:
+    binhash: 23057f815ac36c636a2f004afd2f1031
+    md5: 716b02b3f0edfea11851632f3f1ebcd5
+work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196801010000-196812312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196801010000-196812312100.nc
+  hashes:
+    binhash: 57e8371159afba04b48ac688da2a42ec
+    md5: 7cc9b938c56ccbf1658e3276986888ea
+work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196901010000-196912312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196901010000-196912312100.nc
+  hashes:
+    binhash: d719dd76a74e70ada292bcae61e92a62
+    md5: 075fdeb2919c69c02265cdb988d93e77
+work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197001010000-197012312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197001010000-197012312100.nc
+  hashes:
+    binhash: 1aabe15ee8810c1f1b9d365459860d25
+    md5: c89374d965f52181da7c8cb247eebad9
+work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197101010000-197112312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197101010000-197112312100.nc
+  hashes:
+    binhash: a07a33c2d3c3b9b690cbb888ba995681
+    md5: 88f0d7f8c5d15dec0dbb46823ad73faf
+work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197201010000-197212312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197201010000-197212312100.nc
+  hashes:
+    binhash: 25f801f9454000c8c8eb3e63b4f5f915
+    md5: a4cb6e20f2e516c36915ac4b0f5bb7bf
+work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197301010000-197312312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197301010000-197312312100.nc
+  hashes:
+    binhash: ea95ff016993823bace82108907be951
+    md5: 6b4c6e3006adea96111cf2c1b6062149
+work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197401010000-197412312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197401010000-197412312100.nc
+  hashes:
+    binhash: 07a77f75d2f1df6ece027e5b1e405872
+    md5: 48f06a149a4c3ae72989489944893cf3
+work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197501010000-197512312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197501010000-197512312100.nc
+  hashes:
+    binhash: 90afd94cd3e4b652b7f13c31357abde8
+    md5: 85abe3ff752dd7cbf3694d1d3a902305
+work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197601010000-197612312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197601010000-197612312100.nc
+  hashes:
+    binhash: b81778813b3a30ca0089a1aabd6cf0df
+    md5: 5eec26c40eb9a325ba494eb2c0977963
+work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197701010000-197712312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197701010000-197712312100.nc
+  hashes:
+    binhash: cf13d9d0c8c1aef3331f6a2971f1986e
+    md5: 793ffa3c5dab1e35be580f9a6c1c2cb7
+work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197801010000-197812312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197801010000-197812312100.nc
+  hashes:
+    binhash: 8aa4572a293d6988d9385c35f07e5cf2
+    md5: dae57f7d6ebbff1dddd8fbb11144063f
+work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197901010000-197912312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197901010000-197912312100.nc
+  hashes:
+    binhash: aa131208b4760e73bf2cb7ac9d3b82ec
+    md5: 379e0c8536d785cf6758151ea15e3ec4
+work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198001010000-198012312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198001010000-198012312100.nc
+  hashes:
+    binhash: 0e7fc32cc51a731795a6617a69a26b3d
+    md5: 7d67890c9f9076ef04c6eb68dbbbcca2
+work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198101010000-198112312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198101010000-198112312100.nc
+  hashes:
+    binhash: d3fa0195b9bef32cfdb7d95d60e029e0
+    md5: c9e81efbf97f6fc185fe46cbafdea8ed
+work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198201010000-198212312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198201010000-198212312100.nc
+  hashes:
+    binhash: a75b16f25ef0fe8ce1a45691074fe97d
+    md5: 9a1aa6bf3ddefaf202a2968aa15531fb
+work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198301010000-198312312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198301010000-198312312100.nc
+  hashes:
+    binhash: b73f0ff78f091fc48a4f1c001cafc894
+    md5: e7dd6dd8d47db894c944d04a2c2c7b14
+work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198401010000-198412312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198401010000-198412312100.nc
+  hashes:
+    binhash: 4f00c376dfd13fb8c910bd3cfed7f2bb
+    md5: ed1964e013195df9ab0152596b6e6e96
+work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198501010000-198512312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198501010000-198512312100.nc
+  hashes:
+    binhash: b6f0d93979f58444766436acb7a74ace
+    md5: 1e8816708f7c7c9b02faa2f94419b678
+work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198601010000-198612312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198601010000-198612312100.nc
+  hashes:
+    binhash: fdbf61b7ed007b6c94720c72ca76758d
+    md5: e3ed21e26149d4bcdf58ad01e74f10b0
+work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198701010000-198712312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198701010000-198712312100.nc
+  hashes:
+    binhash: 349208735e65adde9b9e00e1de295b44
+    md5: b64edd04d841b332108b3eefac935e1b
+work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198801010000-198812312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198801010000-198812312100.nc
+  hashes:
+    binhash: af9b9dc9623d1f2f64ceb068c679c4b8
+    md5: b00deb118da332659c876583be9a9229
+work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198901010000-198912312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198901010000-198912312100.nc
+  hashes:
+    binhash: 5b1c50c28feaeca1e19a54c32f91a5f8
+    md5: 71ed68d1861ce7a9712747870fd4f25f
+work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199001010000-199012312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199001010000-199012312100.nc
+  hashes:
+    binhash: 865afcb523ec98a1263b74150af0e00c
+    md5: 0e978a57395c734788da27398bef90be
+work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199101010000-199112312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199101010000-199112312100.nc
+  hashes:
+    binhash: ac50527ec13ce6a7819e6ab676fc4ac5
+    md5: 32a5c1eeebe23cce6cbe3193ab6a972b
+work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199201010000-199212312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199201010000-199212312100.nc
+  hashes:
+    binhash: 10d9f1bef60f400a14309b16e31d74ef
+    md5: 218b829d24f5f8cddb2d0c4bfa45a198
+work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199301010000-199312312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199301010000-199312312100.nc
+  hashes:
+    binhash: 3389c169a1c982b69a7b596190895a43
+    md5: 218fcaff35e4445d007f08da09db4b41
+work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199401010000-199412312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199401010000-199412312100.nc
+  hashes:
+    binhash: 3baccab3ea60b5449044313552be43f1
+    md5: 35748795e67b71fc0cffb587288f0477
+work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199501010000-199512312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199501010000-199512312100.nc
+  hashes:
+    binhash: c09cd61c0a549c7b616f349962c054c0
+    md5: 13abb39e82d6fe4d3616bca19c2c7b95
+work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199601010000-199612312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199601010000-199612312100.nc
+  hashes:
+    binhash: 0aa365c8660547351eba2ea494f0c177
+    md5: a61db0a0b0af0e57b05bf74566434a54
+work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199701010000-199712312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199701010000-199712312100.nc
+  hashes:
+    binhash: 1f7f88d9066bf647403146d3ecb2bacb
+    md5: 89fe8a72c8a96669fbcc0f3c61d56bbf
+work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199801010000-199812312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199801010000-199812312100.nc
+  hashes:
+    binhash: 8a3546794468c1090e380383e3c21a59
+    md5: 6ea9196aa9929d8320c90efe5589573b
+work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199901010000-199912312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199901010000-199912312100.nc
+  hashes:
+    binhash: c714a1565bdd019714ae66b29999203b
+    md5: 45eae9f8878d386af0f3dfdb99617c1a
+work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200001010000-200012312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200001010000-200012312100.nc
+  hashes:
+    binhash: dff5a2d6427d307270d877740236fecb
+    md5: 948abc921f49d7fb0258a7dd1ac26db0
+work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200101010000-200112312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200101010000-200112312100.nc
+  hashes:
+    binhash: 880b6de8e676dd6dd90d159fa26506a0
+    md5: 38391d6f2f41cf450d1c2ce22a29c333
+work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200201010000-200212312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200201010000-200212312100.nc
+  hashes:
+    binhash: bd4a1495c03b23f6605249a2422d8c79
+    md5: badc792c1a5ba2ab3e7ce3a4e1e7804d
+work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200301010000-200312312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200301010000-200312312100.nc
+  hashes:
+    binhash: 0bb1f7c1d593762beb087b9a4b6cca02
+    md5: b836295a0f2942270fae0d035013307f
+work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200401010000-200412312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200401010000-200412312100.nc
+  hashes:
+    binhash: dbe7903cc3a01b6bdc6e8627281efdbe
+    md5: 5e5f4d9440f8d24c23f98d5db64a1884
+work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200501010000-200512312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200501010000-200512312100.nc
+  hashes:
+    binhash: dc6cd21a43efa10a6bf119ca869f13d4
+    md5: eedb8336096b53e4746fd2475a7260ef
+work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200601010000-200612312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200601010000-200612312100.nc
+  hashes:
+    binhash: 9ef788eebeb3792ec8e40cd20d37b27c
+    md5: 1048ecaaa580d4387fee6cc7b419aab8
+work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200701010000-200712312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200701010000-200712312100.nc
+  hashes:
+    binhash: 7b88e4f84809d32a247488f077b0be53
+    md5: c795217a6ffd28cf1c5465e0bab3eb9f
+work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200801010000-200812312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200801010000-200812312100.nc
+  hashes:
+    binhash: 17220c133b9a65c2ff5de2befd7964e6
+    md5: 816c908229a8baba8b91e33883b25d59
+work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200901010000-200912312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200901010000-200912312100.nc
+  hashes:
+    binhash: ed0424e281d4df58ba2d108f9a0d168d
+    md5: 7a552070d34b9194a4085e8bcfd8dc92
+work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201001010000-201012312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201001010000-201012312100.nc
+  hashes:
+    binhash: 8021030fd400d7efb9911b29f90213e8
+    md5: f23d69bc98c4edad0b51dfa42db7238d
+work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201101010000-201112312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201101010000-201112312100.nc
+  hashes:
+    binhash: 2b326485995e89a01b8fe14e8281c382
+    md5: 49b4e942ef603615e4daba5e614819e5
+work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201201010000-201212312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201201010000-201212312100.nc
+  hashes:
+    binhash: ebcdbbbb21d5abdf62da7c12ed0e4158
+    md5: 87e8dc139ad6cac0488d8a86c0ee646f
+work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201301010000-201312312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201301010000-201312312100.nc
+  hashes:
+    binhash: 4328ba6411a7076575d9d8545d17e762
+    md5: 0ed54d0f6e5d6d4ac79535e3774973c1
+work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201401010000-201412312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201401010000-201412312100.nc
+  hashes:
+    binhash: 72feb5ecf5e68eceae716fc5ce45d0cb
+    md5: 27417e5de1837f9585cfb5c2c3304eee
+work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201501010000-201512312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201501010000-201512312100.nc
+  hashes:
+    binhash: a298da26ad06bfe531a8612711b44733
+    md5: 936f58075bf65094bfcaa97da0236671
+work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201601010000-201612312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201601010000-201612312100.nc
+  hashes:
+    binhash: 1fc1eadc5a94d1a964250d1fd95db2c5
+    md5: c5471419a771a865af072020385ab035
+work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201701010000-201712312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201701010000-201712312100.nc
+  hashes:
+    binhash: a0998d64af0077bfe434f2f70eace282
+    md5: dc4273aeae98f6bd7e991c7aef9a2010
+work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201801010000-201812312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201801010000-201812312100.nc
+  hashes:
+    binhash: d309ed31694794b2eddc41bc7e3dc902
+    md5: 5798ad3b37e1e04b3db6a2f684829542
+work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201901010000-201912312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201901010000-201912312100.nc
+  hashes:
+    binhash: a2e2bf5da29cc605f0c6409a48fc81e7
+    md5: 1bb04c3bb38643a3f7c9c848a2475b08
+work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202001010000-202012312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202001010000-202012312100.nc
+  hashes:
+    binhash: 03ccebb339578ea11119b956a245ddd7
+    md5: 806fbde435a2236b0ee74dcd525166a5
+work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202101010000-202112312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202101010000-202112312100.nc
+  hashes:
+    binhash: 064afd45c404c1643a1451eaa127a671
+    md5: 72923997a58b7d45f5f6dbf3c709f9aa
+work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202201010000-202212312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202201010000-202212312100.nc
+  hashes:
+    binhash: bf2b1b07f4416c14276d4fe544c0fa0b
+    md5: b5a507adc6e902e22aef511571b10eb3
+work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202301010000-202312312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202301010000-202312312100.nc
+  hashes:
+    binhash: 23cacafc353d966952fb0887860e539c
+    md5: 5e5c116d874a6a4f7482f3d8ece40df0
+work/atmosphere/INPUT/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202401010000-202402012100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/psl/gr/v20240531/psl_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202401010000-202402012100.nc
+  hashes:
+    binhash: ab966164b5baf633ff45ceba1b69b3a4
+    md5: 649a2cccabd7a80210473b7bc8bb152b
+work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_195801010130-195812312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_195801010130-195812312230.nc
+  hashes:
+    binhash: 610d52d809b5322b3482e02f2dd8001a
+    md5: b0768e6f99b9c60957e4d63c95ce35e2
+work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_195901010130-195912312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_195901010130-195912312230.nc
+  hashes:
+    binhash: b3b4fe37647ef59034eb78e1fdbabe7c
+    md5: 22b41c134fa61a3e5f5b4fa3070d4095
+work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196001010130-196012312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196001010130-196012312230.nc
+  hashes:
+    binhash: 9e2e5ae8b2cbaa3bbbfeafe08493eb5c
+    md5: 4202f18e70c56f076db67814062b0eea
+work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196101010130-196112312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196101010130-196112312230.nc
+  hashes:
+    binhash: eca5cfeb48d67c6ad244acd8f9243254
+    md5: 57a97ef660e2be2dc45084679133d05a
+work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196201010130-196212312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196201010130-196212312230.nc
+  hashes:
+    binhash: aa0ea4cf31ef3d04e78ed44e51995302
+    md5: 6659a236d455b053f9007cdd0a202954
+work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196301010130-196312312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196301010130-196312312230.nc
+  hashes:
+    binhash: bddbd37d8a8c86eed1a79e919b7893b3
+    md5: b34094f79252b4ed63365d052b8e4287
+work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196401010130-196412312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196401010130-196412312230.nc
+  hashes:
+    binhash: 773d7be2edcbf653c052d357e0b453cc
+    md5: 69157a452100353c2ab7ae083490b6e3
+work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196501010130-196512312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196501010130-196512312230.nc
+  hashes:
+    binhash: bfc1a8180f174d47100249fe09381d6d
+    md5: 6be418a543d0804de7a45bbd287b6016
+work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196601010130-196612312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196601010130-196612312230.nc
+  hashes:
+    binhash: 5cbade208e70e497638d4ca6fab24c3d
+    md5: c1999c964f61a3aaa51b58cf8e003835
+work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196701010130-196712312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196701010130-196712312230.nc
+  hashes:
+    binhash: 5c445a0ebd49909cff797e8c5cc020db
+    md5: ff9979805ae5496c04208fc4ffdcc2c5
+work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196801010130-196812312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196801010130-196812312230.nc
+  hashes:
+    binhash: e2e3b9f3fb68a9dcfafa467e12302865
+    md5: 483c9871f63e0baa48f3cfa8bafd34c8
+work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196901010130-196912312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196901010130-196912312230.nc
+  hashes:
+    binhash: 2b7d9eb546ada9b501441c0341cb15f8
+    md5: aee511cd3c0bbfffa1561df7e54514ac
+work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197001010130-197012312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197001010130-197012312230.nc
+  hashes:
+    binhash: 36889c9502206caa206d857a6ac9c457
+    md5: e168164346e5cc6a33e40bb69c2eda8f
+work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197101010130-197112312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197101010130-197112312230.nc
+  hashes:
+    binhash: 3a5e696546a60e40466e3e455e353fcb
+    md5: 2335302eeb5eeaad1e3398b3ba112f5e
+work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197201010130-197212312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197201010130-197212312230.nc
+  hashes:
+    binhash: eb2f50a250cccaf9831f7ac1e14e13c6
+    md5: 376690c442f1e1f9735fe731cdd62bf4
+work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197301010130-197312312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197301010130-197312312230.nc
+  hashes:
+    binhash: 86bf50f935d37e67a631b94fba67f59a
+    md5: 35d4aa61778c1af4e63f896e5df4e79f
+work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197401010130-197412312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197401010130-197412312230.nc
+  hashes:
+    binhash: 15702c0f2464abad1d8fa56b4a6e0b65
+    md5: 87536211cc9fece98b54abbf9091d9b0
+work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197501010130-197512312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197501010130-197512312230.nc
+  hashes:
+    binhash: 7b477dbe9646557ce97e9ad12285cb35
+    md5: c0eee0eedbe8d238379539e7b8921348
+work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197601010130-197612312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197601010130-197612312230.nc
+  hashes:
+    binhash: b39e037c656012e38e72536015cba0f7
+    md5: 6e1e648251d638e8cf59916bba6cf9be
+work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197701010130-197712312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197701010130-197712312230.nc
+  hashes:
+    binhash: 0c444c8788408e6b808ecbf5f6b9ee0c
+    md5: c83774c396a475164430aa6962bb5540
+work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197801010130-197812312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197801010130-197812312230.nc
+  hashes:
+    binhash: b910845750180e67eb016d215923890f
+    md5: 2f9ebb69bb5752d8f901230c43a8600b
+work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197901010130-197912312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197901010130-197912312230.nc
+  hashes:
+    binhash: 9530c571c5c8945cb4d0e568a121dff5
+    md5: ddedd581070b4d59f828f6c2e2130fb1
+work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198001010130-198012312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198001010130-198012312230.nc
+  hashes:
+    binhash: 06a77ad043598bb132a1dbc39403a5fc
+    md5: 9796974133c668e230f4b6427faab408
+work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198101010130-198112312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198101010130-198112312230.nc
+  hashes:
+    binhash: e1ee45df45ef488c6db7add6c2dcdddf
+    md5: 3c4cb8960fe94e674101e9f3ef0ea2c6
+work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198201010130-198212312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198201010130-198212312230.nc
+  hashes:
+    binhash: 65ad993f3287c6015480eaf4ec13721f
+    md5: 6c00ebba9c10d9cc4a398baff1a65c0e
+work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198301010130-198312312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198301010130-198312312230.nc
+  hashes:
+    binhash: 48c4e4671f5acc958bda303acf6e9658
+    md5: 149f2fe0c37da5febed35574f22f6439
+work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198401010130-198412312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198401010130-198412312230.nc
+  hashes:
+    binhash: 8b10a2d746ee50ca2bdde3e0f86e8568
+    md5: 4c99402f48962fbb04a448156afc234d
+work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198501010130-198512312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198501010130-198512312230.nc
+  hashes:
+    binhash: 9e81e0a7b4aef5cb5383ab0c4302b35a
+    md5: dbff4a0c845ab2ef26bd185e4239df4f
+work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198601010130-198612312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198601010130-198612312230.nc
+  hashes:
+    binhash: c46755a07ef015580a5d5e6501a4da22
+    md5: 86be02279f5a6a458961d45779e392c3
+work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198701010130-198712312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198701010130-198712312230.nc
+  hashes:
+    binhash: a87ef480cf3547c4e43e331b9f59038f
+    md5: b388550ed05ae1e56ca95e9d1c4481d7
+work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198801010130-198812312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198801010130-198812312230.nc
+  hashes:
+    binhash: 96e74453f2ceecd7cea4fa5b182f5da8
+    md5: f2be59f7c595b542d4a5e86cd49a2d4a
+work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198901010130-198912312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198901010130-198912312230.nc
+  hashes:
+    binhash: 004d2cff1f8a082d236cc278715eebba
+    md5: 966c84ac7ce08baba75376079a7ef098
+work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199001010130-199012312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199001010130-199012312230.nc
+  hashes:
+    binhash: 3ba357a166b8580111ee38c5509314b5
+    md5: beee87dbad7acac5a28e3ac2caf903b6
+work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199101010130-199112312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199101010130-199112312230.nc
+  hashes:
+    binhash: 6cce3439fce653bd7a20408a6bc0fe74
+    md5: 13bbbed567f3601c1f1bc0cf0f02c485
+work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199201010130-199212312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199201010130-199212312230.nc
+  hashes:
+    binhash: 2e36b532706f28085bb4a8488acdded9
+    md5: 538ea3595faceac953f4f12907dbc9ba
+work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199301010130-199312312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199301010130-199312312230.nc
+  hashes:
+    binhash: 928f2551089e3c51841b7e31d438aba5
+    md5: babea621e1fc8581c7521b8537896e85
+work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199401010130-199412312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199401010130-199412312230.nc
+  hashes:
+    binhash: 679b3f50da1e45c9b89d73743a461084
+    md5: edd2f151284ae73ed2ef1828933e29d7
+work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199501010130-199512312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199501010130-199512312230.nc
+  hashes:
+    binhash: 2e002a9ffa383f111d8acda7ee643e45
+    md5: 58ed7c0961161f98d8fbd2a51b9f0b6c
+work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199601010130-199612312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199601010130-199612312230.nc
+  hashes:
+    binhash: 333e3d98930d97c794b2d6beb1159cea
+    md5: a6572ce230e6989dea35f25d448c8cdc
+work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199701010130-199712312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199701010130-199712312230.nc
+  hashes:
+    binhash: d6b2cdf7ebdc76353e5af0eeac8dbf03
+    md5: 234db87e460d1984eb8887e619a3f95d
+work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199801010130-199812312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199801010130-199812312230.nc
+  hashes:
+    binhash: 28047bacb24fb5110b5242c08e8656de
+    md5: ac0a06208729504d8c083f1afe7275c9
+work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199901010130-199912312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199901010130-199912312230.nc
+  hashes:
+    binhash: 90255ff28aa83058fed2cfa79d9ad99a
+    md5: 22c3c5dea5f60a0386aa502bf58541f3
+work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200001010130-200012312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200001010130-200012312230.nc
+  hashes:
+    binhash: b7a67383e5dfd75dc5dc3754fab02dd3
+    md5: 0b2e3bef7f795dd9286d8696691f00d7
+work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200101010130-200112312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200101010130-200112312230.nc
+  hashes:
+    binhash: 2e208997d37185d53d699e1e49eb166f
+    md5: d0a3800a98f21138f29a72aa8b11d04f
+work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200201010130-200212312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200201010130-200212312230.nc
+  hashes:
+    binhash: c8308434e8d9e96b9ea2f971ad418f39
+    md5: 55284cf035d747892ef8314b2366fd7a
+work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200301010130-200312312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200301010130-200312312230.nc
+  hashes:
+    binhash: 8b5579a4f0594dc52756a2f115d5cfb2
+    md5: 3ef505fd387b50f421f4d9c75f4249f9
+work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200401010130-200412312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200401010130-200412312230.nc
+  hashes:
+    binhash: 61f70687b85daaa4f26c05c98e0c427a
+    md5: fdbe239221ed405ed6effd58dc9a8e54
+work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200501010130-200512312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200501010130-200512312230.nc
+  hashes:
+    binhash: 9fc5fa462400ba957481992581ae687e
+    md5: a8616a2d188574e27adcd56685c75fe7
+work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200601010130-200612312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200601010130-200612312230.nc
+  hashes:
+    binhash: 53597455df64b132ee1351b168ad146f
+    md5: 0fb5f06abf1d91473c742b7d2ef9c01f
+work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200701010130-200712312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200701010130-200712312230.nc
+  hashes:
+    binhash: 86ea7c3acb263a47c3015b60c8ea343c
+    md5: 3b1eef078378c149adab81be6b7df6f8
+work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200801010130-200812312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200801010130-200812312230.nc
+  hashes:
+    binhash: db30cef7e60fa3aaeaf68967787fddd2
+    md5: 62bc0d4d6014be1a7d0dfea7d65dc90c
+work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200901010130-200912312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200901010130-200912312230.nc
+  hashes:
+    binhash: a6abcc36ec365732055788dc3ac583bf
+    md5: ee80b04cb96443374e9da2fffe215db6
+work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201001010130-201012312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201001010130-201012312230.nc
+  hashes:
+    binhash: 74e88566cd2db61048500d8ffbce8342
+    md5: 7eb2913d94336b2b979afa99cff8182f
+work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201101010130-201112312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201101010130-201112312230.nc
+  hashes:
+    binhash: b5d2278c332bebec2ad6b0df7df5d806
+    md5: b4e1dfd785c8a559e33d2f250bdf3a2c
+work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201201010130-201212312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201201010130-201212312230.nc
+  hashes:
+    binhash: b7f3c4dea937b35fb9fa19420e937d6c
+    md5: ed9566a4ee8fa5226be9e9badddfaeac
+work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201301010130-201312312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201301010130-201312312230.nc
+  hashes:
+    binhash: e7928a3a199f4c8d98de9509f5a16c0d
+    md5: 846d2f42c993b513849c4295cf69865c
+work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201401010130-201412312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201401010130-201412312230.nc
+  hashes:
+    binhash: 05e56ea043682a97ce5c1eb6b21240ef
+    md5: b29db5ea7a97e16cf27c028899604122
+work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201501010130-201512312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201501010130-201512312230.nc
+  hashes:
+    binhash: 7488677ee16ae2fa644a31c7e8498c4e
+    md5: 9f2bdd5f682976f961ddbaec5d1da904
+work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201601010130-201612312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201601010130-201612312230.nc
+  hashes:
+    binhash: 588b0cc10d8a1a9b081542a1006820ce
+    md5: 328086a01f18af4617d3c95a1c432ef6
+work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201701010130-201712312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201701010130-201712312230.nc
+  hashes:
+    binhash: c5e5bda96cc133cc92379ce10cf6709c
+    md5: 371e208c57f513778d02b2f58a834c4b
+work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201801010130-201812312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201801010130-201812312230.nc
+  hashes:
+    binhash: c5e20e3b90fe45cc986d865fbf9ffb19
+    md5: b343b6439e4b3d137247965103036175
+work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201901010130-201912312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201901010130-201912312230.nc
+  hashes:
+    binhash: 2511a6fbaa46df30a3c4006bd40ae4d1
+    md5: f057d5ea649468a928553ea4d7ac8ca8
+work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202001010130-202012312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202001010130-202012312230.nc
+  hashes:
+    binhash: d15f4bfecaa6dadf08d4eff1f33fedfa
+    md5: c2f35571c4372005e5e1840eb7241a0d
+work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202101010130-202112312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202101010130-202112312230.nc
+  hashes:
+    binhash: 92c06d20263f5d5449d76c77d1f11f19
+    md5: 16e0f901e23f117de16a2dac87c7fe50
+work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202201010130-202212312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202201010130-202212312230.nc
+  hashes:
+    binhash: 821f9351784beb13f105aa17a5f211f1
+    md5: 8df723419fd3ab9fbe8fb86060df1b2c
+work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202301010130-202312312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202301010130-202312312230.nc
+  hashes:
+    binhash: 960113ed4c608ee0b39eddf91750874b
+    md5: 47be124cbb77865c77f4767482a7cd82
+work/atmosphere/INPUT/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202401010130-202402012230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rlds/gr/v20240531/rlds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202401010130-202402012230.nc
+  hashes:
+    binhash: c0e5a9d7fe3bca7490492940e9a3254c
+    md5: e2391c181002cc6b2c328f08a4b9d170
 work/atmosphere/INPUT/rmp_jrar_to_cict_CONSERV.nc:
   fullpath: /g/data/vk83/configurations/inputs/access-om2/remapping_weights/JRA55/global.01deg/2020.05.30/rmp_jrar_to_cict_CONSERV.nc
   hashes:
     binhash: 2781aaa1d02deebc2bcbe73d1a1d965d
     md5: 08f3f762a1b005d4ba90f5ceef5ccc74
-work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_195801010130-195812312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rsds/gr/v20190429/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_195801010130-195812312230.nc
-  hashes:
-    binhash: 8d0e04d6cc6b2393f2e7f804ee2064f5
-    md5: 43da15cf4d7b073c9ea441fcbb53be89
-work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_195901010130-195912312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rsds/gr/v20190429/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_195901010130-195912312230.nc
-  hashes:
-    binhash: bac436ac62990dd79120f80930819f95
-    md5: 1e5a14a15d36b554d2982e0d31711f21
-work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196001010130-196012312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rsds/gr/v20190429/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196001010130-196012312230.nc
-  hashes:
-    binhash: 98632562e9b13cc0014e03894149baed
-    md5: cb69e89ecddb5332162b0cef9107454b
-work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196101010130-196112312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rsds/gr/v20190429/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196101010130-196112312230.nc
-  hashes:
-    binhash: 54ac033062bce09c70a97fc7fc3cf8ee
-    md5: f603a441ac24e6ba804aecf9dc2cffb6
-work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196201010130-196212312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rsds/gr/v20190429/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196201010130-196212312230.nc
-  hashes:
-    binhash: b3012fd3b5a06e234a322f7d1cf90ec1
-    md5: 98440657c085e56761ed956cf0d414f2
-work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196301010130-196312312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rsds/gr/v20190429/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196301010130-196312312230.nc
-  hashes:
-    binhash: 37459d804e36ba436116cd0618c1ade0
-    md5: 46fad97684ca372532293fc39432ca59
-work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196401010130-196412312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rsds/gr/v20190429/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196401010130-196412312230.nc
-  hashes:
-    binhash: 81183127d9c3ec2678953b2e25d35be7
-    md5: c9087f77bb18764b3bd4703b4686e41b
-work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196501010130-196512312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rsds/gr/v20190429/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196501010130-196512312230.nc
-  hashes:
-    binhash: aa4837c300854968de4666d0ed039c81
-    md5: 0f0360c61b986a6dc098a6ec864a7120
-work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196601010130-196612312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rsds/gr/v20190429/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196601010130-196612312230.nc
-  hashes:
-    binhash: 1dbc7c3493056fe8b15703cdff29bcfd
-    md5: dbc493f6925adc9b23071bbc8073f3b1
-work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196701010130-196712312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rsds/gr/v20190429/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196701010130-196712312230.nc
-  hashes:
-    binhash: f44960eda5d24d475b4cef399cf5e1d5
-    md5: d68916c53caf38b11f10ad664558c5cd
-work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196801010130-196812312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rsds/gr/v20190429/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196801010130-196812312230.nc
-  hashes:
-    binhash: a69d68800a724037e352f86b4defaa1c
-    md5: 4070a5bad1f11f0bfc23b33fe24dc2cf
-work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196901010130-196912312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rsds/gr/v20190429/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196901010130-196912312230.nc
-  hashes:
-    binhash: c204af73d04635453efcd8447c06f5b4
-    md5: 3ad8a5d610a1a5f6c399612abc2ef726
-work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197001010130-197012312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rsds/gr/v20190429/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197001010130-197012312230.nc
-  hashes:
-    binhash: c2b88793220df14cb525b607317b02b7
-    md5: f34242ed72235a67b35955e5b0052b1d
-work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197101010130-197112312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rsds/gr/v20190429/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197101010130-197112312230.nc
-  hashes:
-    binhash: 9fed2c4a190bbb275c3e38f60dcb69b7
-    md5: 7c3b830df81cdbd33d07cd51c6b5a494
-work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197201010130-197212312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rsds/gr/v20190429/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197201010130-197212312230.nc
-  hashes:
-    binhash: 4809a559de60ec78dda27f65f69ab2f9
-    md5: 491b133fa5ad85d676a3d478b4845be7
-work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197301010130-197312312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rsds/gr/v20190429/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197301010130-197312312230.nc
-  hashes:
-    binhash: 3c7530de94186c4c9d73e7af7e543475
-    md5: af01c3709aad562e172a16c470f5c7f5
-work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197401010130-197412312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rsds/gr/v20190429/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197401010130-197412312230.nc
-  hashes:
-    binhash: 6acbd4d43c2638cda10e8fd0cd8348b9
-    md5: d0cb2ed9e4f5aed0ed24f0cb6e6cccb0
-work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197501010130-197512312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rsds/gr/v20190429/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197501010130-197512312230.nc
-  hashes:
-    binhash: fbd7ad4ae534a82c1199e52c296f99b9
-    md5: 2ff0fa4f3623ed89571ffc1e671097cd
-work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197601010130-197612312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rsds/gr/v20190429/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197601010130-197612312230.nc
-  hashes:
-    binhash: ac5b6dd28c51d1c3ceaf9083cd2c3d1c
-    md5: 0a9d79b3bfffb5660aa7e8d175640ece
-work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197701010130-197712312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rsds/gr/v20190429/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197701010130-197712312230.nc
-  hashes:
-    binhash: 88d8b46ca4e22a787203a845df565116
-    md5: 034246fc2ca1609ac9b524897e325136
-work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197801010130-197812312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rsds/gr/v20190429/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197801010130-197812312230.nc
-  hashes:
-    binhash: 561f39ecfe151ba51e6a83a3f031e3d1
-    md5: 6be598ee419a01abf1fda9ead4913cfd
-work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197901010130-197912312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rsds/gr/v20190429/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197901010130-197912312230.nc
-  hashes:
-    binhash: dfd6a208746e4c0a01484ed00f7a5a44
-    md5: 2150e92577358eec0e71bcd97074dfee
-work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198001010130-198012312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rsds/gr/v20190429/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198001010130-198012312230.nc
-  hashes:
-    binhash: 0526f3e1113d2d8efa02a9d77c14afce
-    md5: 477d5e8b37f926a2d9d6b5ab96d3611e
-work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198101010130-198112312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rsds/gr/v20190429/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198101010130-198112312230.nc
-  hashes:
-    binhash: a1fb67c351a7a126942ef2de68b39c51
-    md5: c55b4ee0803a9ad3653b1cefc1d8a094
-work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198201010130-198212312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rsds/gr/v20190429/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198201010130-198212312230.nc
-  hashes:
-    binhash: 76faf9903b29fea6c183156860844687
-    md5: a912a30b96dadc5e12b2519c31a5f351
-work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198301010130-198312312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rsds/gr/v20190429/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198301010130-198312312230.nc
-  hashes:
-    binhash: fb4a395a875f5023832d47a49eefceee
-    md5: f9b397d4049e9d56692469eb604f6ec4
-work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198401010130-198412312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rsds/gr/v20190429/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198401010130-198412312230.nc
-  hashes:
-    binhash: fc9320d6ffa76e44641cc7d94095f233
-    md5: d2c2255f28494d01553ebae50b750412
-work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198501010130-198512312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rsds/gr/v20190429/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198501010130-198512312230.nc
-  hashes:
-    binhash: 9e22352ca08410b6662d669a46de4681
-    md5: 14d6695fd2e3b07c73d68504121534af
-work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198601010130-198612312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rsds/gr/v20190429/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198601010130-198612312230.nc
-  hashes:
-    binhash: 04746b64dab392206ff5f549f06c8706
-    md5: 98e9f3de56570040240fec19db131f52
-work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198701010130-198712312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rsds/gr/v20190429/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198701010130-198712312230.nc
-  hashes:
-    binhash: 5017ef4040a76dddf007a8853582d916
-    md5: 885d384390631ffd3da92e87c78667a3
-work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198801010130-198812312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rsds/gr/v20190429/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198801010130-198812312230.nc
-  hashes:
-    binhash: 46fdf6a77f0542b11bfbd35f86a94173
-    md5: 987f527638e8775d71e87112cac50019
-work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198901010130-198912312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rsds/gr/v20190429/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198901010130-198912312230.nc
-  hashes:
-    binhash: 6a54159751a177f7ba3099cd37968f86
-    md5: 601cdfd8656851fc4980865a4e9f414a
-work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199001010130-199012312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rsds/gr/v20190429/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199001010130-199012312230.nc
-  hashes:
-    binhash: c0ae68fca01168edccb44d3eeefb7d1f
-    md5: 1f278d401082a28fb88279fe7a3f6ef3
-work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199101010130-199112312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rsds/gr/v20190429/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199101010130-199112312230.nc
-  hashes:
-    binhash: 4e4ba9e7136cf036f86b275a5ca7a429
-    md5: ef25240fb10313371c21b24596812f20
-work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199201010130-199212312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rsds/gr/v20190429/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199201010130-199212312230.nc
-  hashes:
-    binhash: 32f9c00fdb06e67e0cc201ea5ce83562
-    md5: b9b79ef7d229405b27f4aae5cd4e995f
-work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199301010130-199312312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rsds/gr/v20190429/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199301010130-199312312230.nc
-  hashes:
-    binhash: 83f3c99672cea2cd2ee77652e976077d
-    md5: a3226e402ebf188bfa8e04b77753cd09
-work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199401010130-199412312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rsds/gr/v20190429/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199401010130-199412312230.nc
-  hashes:
-    binhash: 8f7f4074dbfe519b902fe52834d8a975
-    md5: fae21c44a5d407d32a357b4342f9bdf5
-work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199501010130-199512312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rsds/gr/v20190429/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199501010130-199512312230.nc
-  hashes:
-    binhash: 09ecae87fd0d5c12912c450d499736e0
-    md5: 3341fd134badc0d523629ef61b227234
-work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199601010130-199612312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rsds/gr/v20190429/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199601010130-199612312230.nc
-  hashes:
-    binhash: 23563345d867f5f5dd9a6a00c4c70ebc
-    md5: 28d173d5f2778c8138f61d5971daa655
-work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199701010130-199712312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rsds/gr/v20190429/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199701010130-199712312230.nc
-  hashes:
-    binhash: 51b5d9984d7952d372b99d3b894141ac
-    md5: 34fd97e411ee99c9351740b15598350f
-work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199801010130-199812312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rsds/gr/v20190429/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199801010130-199812312230.nc
-  hashes:
-    binhash: cb8fa42fd0dde3923a03f2fb3f43fdf1
-    md5: 2e23af21b9689bbcf5c9d7cf80d5544c
-work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199901010130-199912312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rsds/gr/v20190429/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199901010130-199912312230.nc
-  hashes:
-    binhash: 377dadb498f654964b3f933d118ecd55
-    md5: 38f83577a4dca49072d199cc297e6b14
-work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200001010130-200012312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rsds/gr/v20190429/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200001010130-200012312230.nc
-  hashes:
-    binhash: 636b30f533d9505baef2f977dd7286a1
-    md5: 4371ea45662cf533fb591e83d5006f7c
-work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200101010130-200112312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rsds/gr/v20190429/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200101010130-200112312230.nc
-  hashes:
-    binhash: 4df218cbb4b462b96ba8da39e61f0712
-    md5: 2d9c694e1cffbdb8ef43b9c1ce9ca19e
-work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200201010130-200212312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rsds/gr/v20190429/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200201010130-200212312230.nc
-  hashes:
-    binhash: 5958b816d71a65048b20521d804cb2f7
-    md5: 9a5ff4ab3c0a6cec9d350d9a0fcb149a
-work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200301010130-200312312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rsds/gr/v20190429/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200301010130-200312312230.nc
-  hashes:
-    binhash: b77d04fe70c9b769198e35cdbb80184c
-    md5: 005a5de650f5c11ad05e66ac84d2d69e
-work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200401010130-200412312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rsds/gr/v20190429/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200401010130-200412312230.nc
-  hashes:
-    binhash: c4bfbf97314ca52d68640cb4425beb22
-    md5: a7b90a41393f9851ba9a588c51ff18d3
-work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200501010130-200512312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rsds/gr/v20190429/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200501010130-200512312230.nc
-  hashes:
-    binhash: c3d6d9df3de5f941dc8a012edd555ba4
-    md5: da6bd7d10c5c31eba29ebe52237c0aa4
-work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200601010130-200612312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rsds/gr/v20190429/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200601010130-200612312230.nc
-  hashes:
-    binhash: 58463fcf2c0ce5043741257971fe1bb8
-    md5: 38f0bcd0d11b45eb37195786241a2a8f
-work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200701010130-200712312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rsds/gr/v20190429/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200701010130-200712312230.nc
-  hashes:
-    binhash: 3c1a50b376454ce6878f5f85d8b5bdd1
-    md5: c52e7c3cbc8c2cdfb2e132272f8d5408
-work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200801010130-200812312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rsds/gr/v20190429/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200801010130-200812312230.nc
-  hashes:
-    binhash: 2757edb0f86f08d2f5116bab2a883aba
-    md5: 995d52a8694ba682f10ada5c5a7eda6e
-work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200901010130-200912312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rsds/gr/v20190429/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200901010130-200912312230.nc
-  hashes:
-    binhash: 65693bf4a8c8c6f1a722aed1d80f5cb8
-    md5: f8eefaa8ff861678677b1c5ec52b4917
-work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201001010130-201012312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rsds/gr/v20190429/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201001010130-201012312230.nc
-  hashes:
-    binhash: a04abe816f7d02d760790142f2e0fcab
-    md5: 5c380b482f10e2f6c104f102ad0ea547
-work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201101010130-201112312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rsds/gr/v20190429/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201101010130-201112312230.nc
-  hashes:
-    binhash: 0bd2d10b7f87be14ed384a7b234af840
-    md5: 50478bf3716f1e6add478a19f7596a1f
-work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201201010130-201212312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rsds/gr/v20190429/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201201010130-201212312230.nc
-  hashes:
-    binhash: b6b8a799b41748eaf037d855ff860e77
-    md5: 5dc34950877f6431c07bbd02b1cc3ff0
-work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201301010130-201312312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rsds/gr/v20190429/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201301010130-201312312230.nc
-  hashes:
-    binhash: 1265a03b15a55646b38a5b247d773feb
-    md5: 0d8719612fe2b0f13565f683cb4e9267
-work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201401010130-201412312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rsds/gr/v20190429/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201401010130-201412312230.nc
-  hashes:
-    binhash: 5616d6d9ceba81fcf11ca670f616a261
-    md5: e7f6d24dff21f3a49ae7c15d46160215
-work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201501010130-201512312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rsds/gr/v20190429/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201501010130-201512312230.nc
-  hashes:
-    binhash: 4282a12f20e700ed743a9432e5f119de
-    md5: 3c20b4c1817b8250b9e00074267c8479
-work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201601010130-201612312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rsds/gr/v20190429/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201601010130-201612312230.nc
-  hashes:
-    binhash: e39a3c1cecc606b9f805a1a9ea885eed
-    md5: dfeb4c1cb89805d940060824aafe8be2
-work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201701010130-201712312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rsds/gr/v20190429/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201701010130-201712312230.nc
-  hashes:
-    binhash: bf305c5732c12e06bfa62bc2a7049104
-    md5: 3834a4cf19fd6fe5e203e724f87a91fa
-work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201801010130-201812312230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rsds/gr/v20190429/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201801010130-201812312230.nc
-  hashes:
-    binhash: 9f3d199da9ee56fb8cd4dac3a01d6125
-    md5: 4155e797a79b271c8c113081584964b1
-work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201901010130-201901052230.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hr/rsds/gr/v20190429/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201901010130-201901052230.nc
-  hashes:
-    binhash: a876199636180b620367770d860bd0a2
-    md5: ff51b282d75d57fa40bd321e3e715684
-work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_195801010000-195812312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/tas/gr/v20190429/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_195801010000-195812312100.nc
-  hashes:
-    binhash: e8d1734d099b10420eeb7cc22ad98b54
-    md5: 755d4ab50b538414c427f72a179e4585
-work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_195901010000-195912312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/tas/gr/v20190429/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_195901010000-195912312100.nc
-  hashes:
-    binhash: b71f4dbf6389a58c9ceebd6090842ed6
-    md5: 7fac14da785b30e4088138915a5eabdb
-work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196001010000-196012312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/tas/gr/v20190429/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196001010000-196012312100.nc
-  hashes:
-    binhash: c3027b07e516ae3e87232933c07fe238
-    md5: f0dac2e9a974360cc46b4e313d146cd5
-work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196101010000-196112312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/tas/gr/v20190429/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196101010000-196112312100.nc
-  hashes:
-    binhash: c9c623cdc7f20a4addf149a949faa73a
-    md5: 35819e6691575aaf0f260d37655bf3bd
-work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196201010000-196212312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/tas/gr/v20190429/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196201010000-196212312100.nc
-  hashes:
-    binhash: 2061cd05e967fc7583d664dc2cafde48
-    md5: e58284401fc5179d50e363e26df1dcb7
-work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196301010000-196312312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/tas/gr/v20190429/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196301010000-196312312100.nc
-  hashes:
-    binhash: 581092e34bdf49a031686254251d3427
-    md5: c1b7d97034074a111262f0906eee36ae
-work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196401010000-196412312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/tas/gr/v20190429/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196401010000-196412312100.nc
-  hashes:
-    binhash: 7f66c09579aeab4ba9f22c635cc11351
-    md5: 70d5f3b5dd59c4964b4c326054a0be53
-work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196501010000-196512312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/tas/gr/v20190429/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196501010000-196512312100.nc
-  hashes:
-    binhash: 7f44c7da2a6d88f73898e4482f093f27
-    md5: f1c63bde825e2941f31301492bd55c6f
-work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196601010000-196612312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/tas/gr/v20190429/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196601010000-196612312100.nc
-  hashes:
-    binhash: db1e5144cfe6ec22d2a8b125053c6356
-    md5: 4973cd6e195d39fb778d921abe41876c
-work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196701010000-196712312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/tas/gr/v20190429/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196701010000-196712312100.nc
-  hashes:
-    binhash: 21c3e9e524e591858deec39cf661c965
-    md5: abae1ea9355a602d1935f9cf777c7679
-work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196801010000-196812312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/tas/gr/v20190429/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196801010000-196812312100.nc
-  hashes:
-    binhash: 8ec081e1ee0d6db204d8360af32d83df
-    md5: 9b4b739a9e6a4a0e1c499a2bfaed95de
-work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196901010000-196912312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/tas/gr/v20190429/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196901010000-196912312100.nc
-  hashes:
-    binhash: 49b49f69535190b9677e5e4ac50bab9e
-    md5: 29092de300d457208027e81421b7d2e9
-work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197001010000-197012312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/tas/gr/v20190429/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197001010000-197012312100.nc
-  hashes:
-    binhash: 3ece09a0105733bb302f51cb89c70fd7
-    md5: 5954703585f99b5cd2420e276b314411
-work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197101010000-197112312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/tas/gr/v20190429/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197101010000-197112312100.nc
-  hashes:
-    binhash: e392fce1da6b720bacfe988e2b02c487
-    md5: 0cb1568ea890e03bcfd3ce556b742282
-work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197201010000-197212312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/tas/gr/v20190429/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197201010000-197212312100.nc
-  hashes:
-    binhash: 51427414a4bf2af0500307c260b710ac
-    md5: 1fd41e7dba7344af7a97c31df50e07bd
-work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197301010000-197312312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/tas/gr/v20190429/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197301010000-197312312100.nc
-  hashes:
-    binhash: 59564840a1c880b673e4ecb98a51364c
-    md5: 49979918a6cea60231aa6eb7bc2b8ee0
-work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197401010000-197412312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/tas/gr/v20190429/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197401010000-197412312100.nc
-  hashes:
-    binhash: 817b0824729d4c2a1e0f993927a5a4aa
-    md5: 48343f5fb6a6a6cc5420c4b92380a45c
-work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197501010000-197512312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/tas/gr/v20190429/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197501010000-197512312100.nc
-  hashes:
-    binhash: 2a9e8a2410ed5786b9634b55c822faaa
-    md5: 9c4ea497c72b514e9fbcf1ee6f3f7a9a
-work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197601010000-197612312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/tas/gr/v20190429/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197601010000-197612312100.nc
-  hashes:
-    binhash: 6449d5ec3d262d436ee8b15a4558a831
-    md5: acf1730160dbb469363424e96a4888ab
-work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197701010000-197712312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/tas/gr/v20190429/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197701010000-197712312100.nc
-  hashes:
-    binhash: 35d6e844e73f55c20f5371fb643c5bdf
-    md5: 11a1ccf9a09bfb8adc2dad621c9d57d4
-work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197801010000-197812312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/tas/gr/v20190429/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197801010000-197812312100.nc
-  hashes:
-    binhash: 0f6d864d5ee93aec22cc709fbd4a8868
-    md5: a6398b65114907fcd330527bd4a73a68
-work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197901010000-197912312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/tas/gr/v20190429/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197901010000-197912312100.nc
-  hashes:
-    binhash: 86018c8c1ac7bff257f66c77085e4cc6
-    md5: 5a69aff36d7707f1d110b177355a419a
-work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198001010000-198012312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/tas/gr/v20190429/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198001010000-198012312100.nc
-  hashes:
-    binhash: 1325e5acdbbd31abd234804f8217c3c3
-    md5: 5b77ba829f4ecb4f51684a319ab33394
-work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198101010000-198112312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/tas/gr/v20190429/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198101010000-198112312100.nc
-  hashes:
-    binhash: e2dd584494134125cd2942a59886a8c4
-    md5: 0a4c5ce26f798efd6efbbb296f2ff067
-work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198201010000-198212312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/tas/gr/v20190429/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198201010000-198212312100.nc
-  hashes:
-    binhash: 2fbed8467b279ce3e63e9754c768ced9
-    md5: aa4f4845142300ddcb98bc1fe72e702a
-work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198301010000-198312312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/tas/gr/v20190429/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198301010000-198312312100.nc
-  hashes:
-    binhash: 10e3587a510c49756486090175f39b01
-    md5: c3211fb6a2c8a4ee2293e8f32dcd4115
-work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198401010000-198412312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/tas/gr/v20190429/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198401010000-198412312100.nc
-  hashes:
-    binhash: d1af936a5e5d42f2c16e1eb047a4d6ec
-    md5: ba68ac72d28a0d359c0249452f62227d
-work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198501010000-198512312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/tas/gr/v20190429/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198501010000-198512312100.nc
-  hashes:
-    binhash: d76e8583219b8a9d247638b1d51c00e4
-    md5: b01ebf2142849d2c1d87f17c1adc0f24
-work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198601010000-198612312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/tas/gr/v20190429/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198601010000-198612312100.nc
-  hashes:
-    binhash: eb8794d728dbd112dd8809fbacfcbed3
-    md5: aff01872c7090d3e2a9698ca1bbd6f65
-work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198701010000-198712312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/tas/gr/v20190429/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198701010000-198712312100.nc
-  hashes:
-    binhash: fbdd71e95687662b401ae3659d023e9c
-    md5: 12d718e1759fc50f3a9d4b983d7ecd27
-work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198801010000-198812312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/tas/gr/v20190429/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198801010000-198812312100.nc
-  hashes:
-    binhash: 6e51cb3514aaa965b053cb9797f08d75
-    md5: 3e245362fb71e4746b5abdab1cad18d8
-work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198901010000-198912312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/tas/gr/v20190429/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198901010000-198912312100.nc
-  hashes:
-    binhash: d438289114b3af96287389dee22d8ef2
-    md5: ec114d9b13ab5ab9e18bf0fefb6b36dd
-work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199001010000-199012312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/tas/gr/v20190429/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199001010000-199012312100.nc
-  hashes:
-    binhash: 04fa4ed93771f04eed0cae8a2b480607
-    md5: 6d82604be6649dee82f9bd35594471f5
-work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199101010000-199112312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/tas/gr/v20190429/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199101010000-199112312100.nc
-  hashes:
-    binhash: 916cd4bf94a12224c7c59e7acba0cfbd
-    md5: 88db5735b8b19926dade0b05f9f82539
-work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199201010000-199212312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/tas/gr/v20190429/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199201010000-199212312100.nc
-  hashes:
-    binhash: e6c28f2c7b899623e87a40d7fbcfe276
-    md5: fc0265a8a225ec5eb33c7ae301fa4497
-work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199301010000-199312312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/tas/gr/v20190429/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199301010000-199312312100.nc
-  hashes:
-    binhash: e65341515b3f6c8961d3f51d996d794a
-    md5: 86c5fe383c9ebca1905872f6c0d4f400
-work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199401010000-199412312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/tas/gr/v20190429/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199401010000-199412312100.nc
-  hashes:
-    binhash: 651c650f7065522a94ada5ad124da92d
-    md5: cff860e9668c1d9788c2c10c71c2f3e2
-work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199501010000-199512312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/tas/gr/v20190429/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199501010000-199512312100.nc
-  hashes:
-    binhash: 45899d004c5da09342ee723d14398cb8
-    md5: 1d2421cce035a481b1c99ba030edee4e
-work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199601010000-199612312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/tas/gr/v20190429/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199601010000-199612312100.nc
-  hashes:
-    binhash: 21dc820d1eaee443493436c1cf107191
-    md5: 19ed187d370d6af4b1a48cc1046e396c
-work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199701010000-199712312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/tas/gr/v20190429/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199701010000-199712312100.nc
-  hashes:
-    binhash: 8adcebc2bddb070b6703e1f94ed53dbc
-    md5: d197c9d5b0da450f02afbd0220c4da96
-work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199801010000-199812312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/tas/gr/v20190429/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199801010000-199812312100.nc
-  hashes:
-    binhash: 22bc89934e2b9ab97edf36bf7f198c8f
-    md5: 437a24bd453376fa5561546174e56dd6
-work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199901010000-199912312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/tas/gr/v20190429/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199901010000-199912312100.nc
-  hashes:
-    binhash: abb64dd80ce8888ccecf37273f4b9f55
-    md5: d5ad92e8c70d15b8a2bb7679a69e38b6
-work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200001010000-200012312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/tas/gr/v20190429/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200001010000-200012312100.nc
-  hashes:
-    binhash: 7bb6d52aba7dab3659d12906ab55ce47
-    md5: ddf82c08efae66effab6901d19c77bde
-work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200101010000-200112312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/tas/gr/v20190429/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200101010000-200112312100.nc
-  hashes:
-    binhash: 32290175ba13e9891c90b9de61c085aa
-    md5: 7fc42ed479f1dc658549077017f5284f
-work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200201010000-200212312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/tas/gr/v20190429/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200201010000-200212312100.nc
-  hashes:
-    binhash: ef5a8a6310ae998428ddd79058d2d000
-    md5: d41db4afaa477da062d0b76b537b22a8
-work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200301010000-200312312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/tas/gr/v20190429/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200301010000-200312312100.nc
-  hashes:
-    binhash: 0809e4bea260c90643603121c9a22f7a
-    md5: 23feaf0f39714766f23027701bc47a77
-work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200401010000-200412312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/tas/gr/v20190429/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200401010000-200412312100.nc
-  hashes:
-    binhash: ef733fe39492e03fc22994ce9cb9e2c0
-    md5: 13ebbbd0f91adeee09e8afa842a691ba
-work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200501010000-200512312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/tas/gr/v20190429/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200501010000-200512312100.nc
-  hashes:
-    binhash: 67c9e00d93c9ef411b3f8138d8f03071
-    md5: dfc80b3630f6a65eb6109cd998f5d87a
-work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200601010000-200612312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/tas/gr/v20190429/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200601010000-200612312100.nc
-  hashes:
-    binhash: b85b17f62f16d41499d2a65562c23ec7
-    md5: d9d9e06854d4e442daa6b3c838fb7ad8
-work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200701010000-200712312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/tas/gr/v20190429/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200701010000-200712312100.nc
-  hashes:
-    binhash: dfea50f7968aaebca17a51487fc10cfb
-    md5: d96bd88ce6892298593426a35c8f1aa4
-work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200801010000-200812312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/tas/gr/v20190429/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200801010000-200812312100.nc
-  hashes:
-    binhash: c73becb1c55b99ae0d02627bf4ef2f32
-    md5: b97f7695fcecf209c8bc41e1c589fb87
-work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200901010000-200912312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/tas/gr/v20190429/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200901010000-200912312100.nc
-  hashes:
-    binhash: c06834d1b171733c3dee3ef64982e3fd
-    md5: 0b3ad914b5dbbe4113ff424b3a21f9c1
-work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201001010000-201012312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/tas/gr/v20190429/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201001010000-201012312100.nc
-  hashes:
-    binhash: 2cd62d248b27d9387abf88961dcfc354
-    md5: ce584b1dfda9bc3fd0a77569fd1ec764
-work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201101010000-201112312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/tas/gr/v20190429/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201101010000-201112312100.nc
-  hashes:
-    binhash: c9b8877e27f82b48bd6c5fb0a5ca743a
-    md5: 722ec4eb9f2c26cbebd6e92834887dcf
-work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201201010000-201212312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/tas/gr/v20190429/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201201010000-201212312100.nc
-  hashes:
-    binhash: b6fc1d42a6f9d826b88a38f3dd0e1299
-    md5: ea5ee3e39b7e2b1973f22f0d5a7ead90
-work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201301010000-201312312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/tas/gr/v20190429/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201301010000-201312312100.nc
-  hashes:
-    binhash: e25fe0399f4a54bd922d54af6407826d
-    md5: 1d4da457b3504f9907fe3021477c26d5
-work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201401010000-201412312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/tas/gr/v20190429/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201401010000-201412312100.nc
-  hashes:
-    binhash: f1c40cc2db6ee6b75037c3be279b6920
-    md5: 6cbe196d75610b65ecd6ad252214b98c
-work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201501010000-201512312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/tas/gr/v20190429/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201501010000-201512312100.nc
-  hashes:
-    binhash: 2af34add81b65bfa1e04a12a4933fa52
-    md5: 81143fddab6b8a15add02f7cd28214d7
-work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201601010000-201612312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/tas/gr/v20190429/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201601010000-201612312100.nc
-  hashes:
-    binhash: 8b053014f41943ce9661671baa3713bc
-    md5: 743cc6c905a02687e8e1a94f728a6b08
-work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201701010000-201712312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/tas/gr/v20190429/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201701010000-201712312100.nc
-  hashes:
-    binhash: b45d6052247055f52b5893a484b26416
-    md5: 58d32c4d0756f8ef80e1bf7dc3ae6d7d
-work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201801010000-201812312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/tas/gr/v20190429/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201801010000-201812312100.nc
-  hashes:
-    binhash: 0689fa0672a90b9720fdf52a6514b213
-    md5: 481d502f68b96fdbdbc4e8ddc053be3e
-work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201901010000-201901052100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/tas/gr/v20190429/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201901010000-201901052100.nc
-  hashes:
-    binhash: 4f94260ac016eb78c443ba784c78a669
-    md5: 837cc3100dccb5252d76eeb62d189cda
-work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_195801010000-195812312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/uas/gr/v20190429/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_195801010000-195812312100.nc
-  hashes:
-    binhash: 153d58bec1893db922e34844841d1755
-    md5: f8f26334a11ceec8ee9073c49772eefa
-work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_195901010000-195912312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/uas/gr/v20190429/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_195901010000-195912312100.nc
-  hashes:
-    binhash: 48e285221ca42d0b74386a9c78760f12
-    md5: cc4ce396b43b48121eea7320ca945a90
-work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196001010000-196012312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/uas/gr/v20190429/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196001010000-196012312100.nc
-  hashes:
-    binhash: d9636c8270c5beed8f8912e6a495c1ff
-    md5: 199e7f4a216893e2fad2e57525f06ca0
-work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196101010000-196112312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/uas/gr/v20190429/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196101010000-196112312100.nc
-  hashes:
-    binhash: 1c8614bcd9394f8e2b0a85ecb46575a4
-    md5: 613be08ae77d6906a5ab55231e6eb6a1
-work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196201010000-196212312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/uas/gr/v20190429/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196201010000-196212312100.nc
-  hashes:
-    binhash: eacd61fafec96175e5f653d1d9b31ab1
-    md5: 94f6fe63b24a4e8de8b651187443db37
-work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196301010000-196312312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/uas/gr/v20190429/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196301010000-196312312100.nc
-  hashes:
-    binhash: 908e5d6a0748e754aad2556b0f29d96d
-    md5: 51e1372b7007c4fb358f984c0256c7a8
-work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196401010000-196412312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/uas/gr/v20190429/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196401010000-196412312100.nc
-  hashes:
-    binhash: 610b4d75984efc7bed812b728d075e24
-    md5: 2b87b2805ee319c1399d5a5e0c23cb69
-work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196501010000-196512312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/uas/gr/v20190429/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196501010000-196512312100.nc
-  hashes:
-    binhash: 2304cba075d972806a8963731d780ab7
-    md5: a7585d28983e9cc31e235af40b92f6c9
-work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196601010000-196612312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/uas/gr/v20190429/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196601010000-196612312100.nc
-  hashes:
-    binhash: 3ea150b61b6bcf636292c595bf6f8661
-    md5: 016380be2a51fd4f8e84341748af2ef9
-work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196701010000-196712312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/uas/gr/v20190429/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196701010000-196712312100.nc
-  hashes:
-    binhash: f6241fe8bda25eba613190b9bb34c349
-    md5: 81d91312de7b85cedf8e545be8e41d1f
-work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196801010000-196812312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/uas/gr/v20190429/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196801010000-196812312100.nc
-  hashes:
-    binhash: 057b25f4c8fd8b5975123fb633100266
-    md5: 8db9bb63f30aedc87e3701d4c8549cff
-work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196901010000-196912312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/uas/gr/v20190429/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196901010000-196912312100.nc
-  hashes:
-    binhash: 634847f87069d18daa802181f2a6542b
-    md5: b048f92370b6cb9797c1be2d9c44d795
-work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197001010000-197012312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/uas/gr/v20190429/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197001010000-197012312100.nc
-  hashes:
-    binhash: 879ecfd4c548067c098037433a43a322
-    md5: 13c6ebabd25593fe3bdb10e805f6447f
-work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197101010000-197112312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/uas/gr/v20190429/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197101010000-197112312100.nc
-  hashes:
-    binhash: 89a277b9d85259e19b4dc371192e07c2
-    md5: ee8442f9a26ad158c9666c109b5a8c39
-work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197201010000-197212312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/uas/gr/v20190429/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197201010000-197212312100.nc
-  hashes:
-    binhash: e33981817dc18c3f7aeffdc600982a78
-    md5: 16ecd05941f992a239345bc1edf6d301
-work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197301010000-197312312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/uas/gr/v20190429/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197301010000-197312312100.nc
-  hashes:
-    binhash: 83d8e746d399c63d64819ff6090c368b
-    md5: 8de6e5efe6c1ac6cec95495ca2c00771
-work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197401010000-197412312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/uas/gr/v20190429/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197401010000-197412312100.nc
-  hashes:
-    binhash: cda30655e9f4a8cc38345cda61bf4b0f
-    md5: 4a7a5a77bd67def0854b768abdcbe2d3
-work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197501010000-197512312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/uas/gr/v20190429/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197501010000-197512312100.nc
-  hashes:
-    binhash: df8340de1b4ae3fd4681242d9c56eb5f
-    md5: dde4de1cfbcabc4be21e8ac210c7d248
-work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197601010000-197612312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/uas/gr/v20190429/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197601010000-197612312100.nc
-  hashes:
-    binhash: bec7a6f5377c5e493ef9f6274af47683
-    md5: 1f1c727a556cfc499a66b0e0552cb521
-work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197701010000-197712312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/uas/gr/v20190429/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197701010000-197712312100.nc
-  hashes:
-    binhash: d6fa2e1ab5a5f4df2daf837f02225174
-    md5: bfd6be883985bbb80a97b1572c2f28cf
-work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197801010000-197812312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/uas/gr/v20190429/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197801010000-197812312100.nc
-  hashes:
-    binhash: d0fb5cee70796ff478d3c8f79317b59f
-    md5: 53d96b2c4c6fa773168f529c2d1ad1e9
-work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197901010000-197912312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/uas/gr/v20190429/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197901010000-197912312100.nc
-  hashes:
-    binhash: e14e268da8c432a890b6ce6a7df31128
-    md5: bb571632efdbefcc2a5b94b1214c1f80
-work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198001010000-198012312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/uas/gr/v20190429/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198001010000-198012312100.nc
-  hashes:
-    binhash: 69909a4c7513d8b539e7f9585e010b37
-    md5: 4dcf2b49bae3691da52b316f4219115d
-work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198101010000-198112312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/uas/gr/v20190429/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198101010000-198112312100.nc
-  hashes:
-    binhash: 27839bffada001344f81fa32d024599b
-    md5: 32ebc7bc24853997e567efabc9810cbc
-work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198201010000-198212312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/uas/gr/v20190429/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198201010000-198212312100.nc
-  hashes:
-    binhash: 74a585f4e14b2fe253142722936fdb13
-    md5: c3ffef70433e16714cce6b4f5259d0c5
-work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198301010000-198312312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/uas/gr/v20190429/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198301010000-198312312100.nc
-  hashes:
-    binhash: d53dd01aed069e8952188e312b74cee4
-    md5: 6fe0808b9b9c0c9c1605a6cf72a23165
-work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198401010000-198412312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/uas/gr/v20190429/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198401010000-198412312100.nc
-  hashes:
-    binhash: e07e53be00e983d064c33aa929f1c66b
-    md5: 5bf7099a5d3f47d8e7fd13826e10c3eb
-work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198501010000-198512312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/uas/gr/v20190429/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198501010000-198512312100.nc
-  hashes:
-    binhash: d7617a12d7fc5d1cb0ff189e338e16b5
-    md5: 5fa238db37aaa99b93a368d24a9954bf
-work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198601010000-198612312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/uas/gr/v20190429/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198601010000-198612312100.nc
-  hashes:
-    binhash: 5b39541e55a4ae0513550c04b0343425
-    md5: a6f7ed5fde24f5f63c8cddf238e62801
-work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198701010000-198712312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/uas/gr/v20190429/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198701010000-198712312100.nc
-  hashes:
-    binhash: 7bd4d5aa83a528639fb2e2145d2c34f6
-    md5: d85572c4d7d0e7c1beb2b1243f779b1d
-work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198801010000-198812312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/uas/gr/v20190429/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198801010000-198812312100.nc
-  hashes:
-    binhash: 96977549d613d4aaf3a665713ac25de6
-    md5: b473c3f955e6524673d833d8f9c8565f
-work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198901010000-198912312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/uas/gr/v20190429/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198901010000-198912312100.nc
-  hashes:
-    binhash: 8cb7435f3c60589ea108c5fbfa9bf0c3
-    md5: c63b0158dc4c3495cae185cf4fb25b71
-work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199001010000-199012312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/uas/gr/v20190429/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199001010000-199012312100.nc
-  hashes:
-    binhash: e93970e12f8c5d1b847c3e2a94d55062
-    md5: fb368a91364700083025b03a21b865f7
-work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199101010000-199112312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/uas/gr/v20190429/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199101010000-199112312100.nc
-  hashes:
-    binhash: 8ad632bdae70acde5dc538bb59bc1459
-    md5: 02eb59363f0c9e113c74571e20568eac
-work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199201010000-199212312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/uas/gr/v20190429/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199201010000-199212312100.nc
-  hashes:
-    binhash: ec81d1037104ff769e6cc3bdb7645409
-    md5: d1d1d09a9703e2ceacc2a0ce526f3a80
-work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199301010000-199312312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/uas/gr/v20190429/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199301010000-199312312100.nc
-  hashes:
-    binhash: e22232bc4ca2e58eb922560ac7abc7eb
-    md5: c75f827eb1f4f285033a1fcdfc1f1e81
-work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199401010000-199412312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/uas/gr/v20190429/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199401010000-199412312100.nc
-  hashes:
-    binhash: 82a06c8c1ef490e2b231b89355255cc4
-    md5: 4beeefd8074fd382e6c65116be3f6af1
-work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199501010000-199512312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/uas/gr/v20190429/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199501010000-199512312100.nc
-  hashes:
-    binhash: f5977be43bcdf5ec5135b7f52af5fefa
-    md5: 50b8b5ab5512202ff0194f78dd4fdd23
-work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199601010000-199612312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/uas/gr/v20190429/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199601010000-199612312100.nc
-  hashes:
-    binhash: 5c8346dd4c0b92fe23ab1baa4de70837
-    md5: 0d24eacd18a5f05883ac89d62279f85c
-work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199701010000-199712312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/uas/gr/v20190429/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199701010000-199712312100.nc
-  hashes:
-    binhash: 7b3c63d0a1f37c67666107db750a04a7
-    md5: 88f9d1ea3d7b99d9f799334fc5aae108
-work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199801010000-199812312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/uas/gr/v20190429/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199801010000-199812312100.nc
-  hashes:
-    binhash: c4f91ba4fcd96426f7e6c4b9f8cd9eb9
-    md5: 686a9d256403e6a48fadc39cd496a687
-work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199901010000-199912312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/uas/gr/v20190429/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199901010000-199912312100.nc
-  hashes:
-    binhash: d4cbafdd0cd82fee1ac20122822e8137
-    md5: a6c30264f73a5d86b36947c2ec5bebe2
-work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200001010000-200012312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/uas/gr/v20190429/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200001010000-200012312100.nc
-  hashes:
-    binhash: 319b699c5a76fabd84214089c6384ebc
-    md5: 9ba33f0919d77e1ea584cbc7b828b018
-work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200101010000-200112312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/uas/gr/v20190429/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200101010000-200112312100.nc
-  hashes:
-    binhash: 661c4c36a618c729af24a9574c860a86
-    md5: f544b1ba7a8c7917784d34a890eaf52a
-work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200201010000-200212312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/uas/gr/v20190429/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200201010000-200212312100.nc
-  hashes:
-    binhash: 97d844ee7580d92f30923657d8b64557
-    md5: bfaa66c178378afd5dd918e4a8dc2f81
-work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200301010000-200312312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/uas/gr/v20190429/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200301010000-200312312100.nc
-  hashes:
-    binhash: 8560d5e791c2914b1b73b9cd0b515fd5
-    md5: 71889cb0d5e857e86fab8fe4a9d62834
-work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200401010000-200412312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/uas/gr/v20190429/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200401010000-200412312100.nc
-  hashes:
-    binhash: fb93e871966eca389891bb1c354d521a
-    md5: 61075e4901735b053723e648014f3a2d
-work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200501010000-200512312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/uas/gr/v20190429/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200501010000-200512312100.nc
-  hashes:
-    binhash: 54eb29486a79d55004ccd51e792deaf5
-    md5: 32e0233598844ebcf1c5d35ffb24c5c5
-work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200601010000-200612312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/uas/gr/v20190429/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200601010000-200612312100.nc
-  hashes:
-    binhash: b4791ea23834007508d5bed1f7b179b5
-    md5: 6e63de950d3590ab0d435fa7804254df
-work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200701010000-200712312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/uas/gr/v20190429/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200701010000-200712312100.nc
-  hashes:
-    binhash: b0a6441173e97466003dce2d487cee9a
-    md5: e8fc00baa9849bb743ab2edc4bce89dd
-work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200801010000-200812312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/uas/gr/v20190429/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200801010000-200812312100.nc
-  hashes:
-    binhash: 371f564c7ae03d5f035fed97db6596ae
-    md5: 47f8fcb650feed968fcfe1b4954851ea
-work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200901010000-200912312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/uas/gr/v20190429/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200901010000-200912312100.nc
-  hashes:
-    binhash: 68f60ae18f4962c948359d4fe8420139
-    md5: 971c8d6fc7c85d22cc32e39c1a66f990
-work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201001010000-201012312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/uas/gr/v20190429/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201001010000-201012312100.nc
-  hashes:
-    binhash: 1b6ef15d8a65cd3c1160978ccc09058e
-    md5: 06a3bbb30382d3f580ffa795f45e90c1
-work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201101010000-201112312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/uas/gr/v20190429/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201101010000-201112312100.nc
-  hashes:
-    binhash: c174c53af727340fbd5c57bc29b9bbc0
-    md5: 1fc46b4e5b730b4109f3799465d9db3d
-work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201201010000-201212312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/uas/gr/v20190429/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201201010000-201212312100.nc
-  hashes:
-    binhash: 82ae822497a63c9a6081a29bfbe3d2cd
-    md5: fb6b13062f5340be170642dbab597eae
-work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201301010000-201312312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/uas/gr/v20190429/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201301010000-201312312100.nc
-  hashes:
-    binhash: 05b5c6fa7636f42ca82fd7ce4a9382b5
-    md5: 432992a93ce94a989c0e5b4e3b73fae0
-work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201401010000-201412312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/uas/gr/v20190429/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201401010000-201412312100.nc
-  hashes:
-    binhash: 2c8864a380c17169ace3730a3b27810e
-    md5: 76ae4d3760c6226e5cdb8de18199795b
-work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201501010000-201512312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/uas/gr/v20190429/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201501010000-201512312100.nc
-  hashes:
-    binhash: 94d612001af25e939d3d325a0400450a
-    md5: 8c2c4bc68475836d56950966a274ea44
-work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201601010000-201612312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/uas/gr/v20190429/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201601010000-201612312100.nc
-  hashes:
-    binhash: d5f4d89b8a444d3b56756482e39cecaa
-    md5: 2bd32147229d8fa7ca5b296c26d0b9d3
-work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201701010000-201712312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/uas/gr/v20190429/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201701010000-201712312100.nc
-  hashes:
-    binhash: 842c4cc38724029b04ba34a740d1eefe
-    md5: 27ba3f7183b755cb314733e0b961eb7a
-work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201801010000-201812312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/uas/gr/v20190429/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201801010000-201812312100.nc
-  hashes:
-    binhash: be0c24bec088f10ed7b15c6204d172eb
-    md5: a4ef43a69d789594cc1700d3cf3abbfc
-work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201901010000-201901052100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/uas/gr/v20190429/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201901010000-201901052100.nc
-  hashes:
-    binhash: a917b6071e8898033e407b67c0b206d4
-    md5: f1cdb45f72e9f95dff0c244f005a9c4c
-work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_195801010000-195812312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/vas/gr/v20190429/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_195801010000-195812312100.nc
-  hashes:
-    binhash: 61c59b8ffb7dce2bc8e0c0c91ede4d86
-    md5: 34b51a3d8bef9014a2beb8acdc7de5e3
-work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_195901010000-195912312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/vas/gr/v20190429/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_195901010000-195912312100.nc
-  hashes:
-    binhash: 4bf5afbae0ab42bfdf624c36d439a0eb
-    md5: ddb1917962604be400897a3f28f27f49
-work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196001010000-196012312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/vas/gr/v20190429/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196001010000-196012312100.nc
-  hashes:
-    binhash: 1269862d661eab4df0e26573ee151318
-    md5: 6c441e255ca7419f976fd5c7aad02aea
-work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196101010000-196112312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/vas/gr/v20190429/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196101010000-196112312100.nc
-  hashes:
-    binhash: 139475fbe54fbd91da1ca539d142d83b
-    md5: 6ec38549b620d1c9f3d5aee86d5d88ad
-work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196201010000-196212312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/vas/gr/v20190429/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196201010000-196212312100.nc
-  hashes:
-    binhash: bd1e32f6cf5452d635ab4c3b607c8d8c
-    md5: c806c3313394003ce5ddddb1199d4147
-work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196301010000-196312312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/vas/gr/v20190429/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196301010000-196312312100.nc
-  hashes:
-    binhash: 9e3b49752b998016dd4dda02841ed2fd
-    md5: a1ebd3af8f82962ce8c19075717ad6d2
-work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196401010000-196412312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/vas/gr/v20190429/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196401010000-196412312100.nc
-  hashes:
-    binhash: f83e0eebf32588826f4498720f9c23f4
-    md5: e353bcb0970698ba5259afc9c8b2a671
-work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196501010000-196512312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/vas/gr/v20190429/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196501010000-196512312100.nc
-  hashes:
-    binhash: a128236e0e40f493a40635adbdc40e01
-    md5: d08d0b065fcceb78ca91ae920da7124a
-work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196601010000-196612312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/vas/gr/v20190429/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196601010000-196612312100.nc
-  hashes:
-    binhash: 79616e9a844761987b621db8c9471ee9
-    md5: fa9f2ab4c045f9a5bda50f41f278fc5f
-work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196701010000-196712312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/vas/gr/v20190429/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196701010000-196712312100.nc
-  hashes:
-    binhash: 7c2f93ae3016ec8e1fa8a5491b52139d
-    md5: dbe295d9676bd7197378403d14a69b5c
-work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196801010000-196812312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/vas/gr/v20190429/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196801010000-196812312100.nc
-  hashes:
-    binhash: b188d4013707f9c0516450cd9ae2ebfd
-    md5: c3c8fbf4d7207535f623197832f0e913
-work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196901010000-196912312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/vas/gr/v20190429/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_196901010000-196912312100.nc
-  hashes:
-    binhash: 5c28fa1b5c3edbd58f3c381aeabcd92f
-    md5: 91c79321016467a3e5e135307d7e7a05
-work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197001010000-197012312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/vas/gr/v20190429/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197001010000-197012312100.nc
-  hashes:
-    binhash: 786eed3bb338d57efb3c2ed837fd7398
-    md5: f1d2a03a3fe51b5d10007e531c3590aa
-work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197101010000-197112312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/vas/gr/v20190429/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197101010000-197112312100.nc
-  hashes:
-    binhash: 5777e3c593aff7b220ad97d8c0e72355
-    md5: fcbc9ec3adff83f58e9bf7d17f776a41
-work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197201010000-197212312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/vas/gr/v20190429/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197201010000-197212312100.nc
-  hashes:
-    binhash: 3c05b52f25246c5f80c72a2fbfa72def
-    md5: 9b8588004d361177bb7e906d8c64a3e8
-work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197301010000-197312312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/vas/gr/v20190429/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197301010000-197312312100.nc
-  hashes:
-    binhash: 5b34ec9f8c61540f6c9a29976916c520
-    md5: 2e63bc734aacc19015899dd1800df881
-work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197401010000-197412312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/vas/gr/v20190429/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197401010000-197412312100.nc
-  hashes:
-    binhash: f3bc4cb2f1fcb4e1f6da93f00159bc60
-    md5: 4a136963ca9351164c810c8695bce9e0
-work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197501010000-197512312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/vas/gr/v20190429/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197501010000-197512312100.nc
-  hashes:
-    binhash: 4ea210b0422be98921aeab3cbfead1ee
-    md5: 4604f3fbd5c54c34b939e75e4676fe72
-work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197601010000-197612312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/vas/gr/v20190429/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197601010000-197612312100.nc
-  hashes:
-    binhash: 8ce12874304322d7bbde02feead0fa38
-    md5: bfec1cfa1ef90b80d908d103b7a840b4
-work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197701010000-197712312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/vas/gr/v20190429/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197701010000-197712312100.nc
-  hashes:
-    binhash: 283d1a3e860f475be98608c8948a9d05
-    md5: be6553575de65740c3b6bc3b2b332d29
-work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197801010000-197812312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/vas/gr/v20190429/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197801010000-197812312100.nc
-  hashes:
-    binhash: 937feaf02bb1bfa2d67309b0385abd48
-    md5: fe002bad672ea7a998e8e059eff6ba79
-work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197901010000-197912312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/vas/gr/v20190429/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_197901010000-197912312100.nc
-  hashes:
-    binhash: 0e13ada75390e866a4c31ac0d7dc8788
-    md5: 1a7f05e337e417d9917e0fb388c7cc7d
-work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198001010000-198012312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/vas/gr/v20190429/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198001010000-198012312100.nc
-  hashes:
-    binhash: 305d57f1e4cf26766bc75e1a4310a3a4
-    md5: 904518781f829ae03ea3705232a94a70
-work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198101010000-198112312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/vas/gr/v20190429/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198101010000-198112312100.nc
-  hashes:
-    binhash: 87323493d808b28a28d2710f14dd3a1a
-    md5: d3ada444665daaf58dc745e4b4227dec
-work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198201010000-198212312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/vas/gr/v20190429/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198201010000-198212312100.nc
-  hashes:
-    binhash: 9d95918da0172c10cec6329e55dfd9bf
-    md5: f32f3287929b0bbd5aa76f49e64d3c31
-work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198301010000-198312312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/vas/gr/v20190429/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198301010000-198312312100.nc
-  hashes:
-    binhash: b0595a54bdee18550cf19a459e23bbba
-    md5: e0a90943ec115c803dd6e3675fb42ee5
-work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198401010000-198412312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/vas/gr/v20190429/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198401010000-198412312100.nc
-  hashes:
-    binhash: b68e0b82911c20aec05ec7b8262080b5
-    md5: 0dbfe35bbbfd0131ca08ec840db3f06b
-work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198501010000-198512312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/vas/gr/v20190429/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198501010000-198512312100.nc
-  hashes:
-    binhash: 4448d42a6745fad9434d74c06f94e517
-    md5: 85e580c1419a65d2a0885455589c8996
-work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198601010000-198612312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/vas/gr/v20190429/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198601010000-198612312100.nc
-  hashes:
-    binhash: a6b6bde185116c2c564914559f85d11c
-    md5: 2276cb6bebb9fd16370d5bdb960bb931
-work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198701010000-198712312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/vas/gr/v20190429/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198701010000-198712312100.nc
-  hashes:
-    binhash: e8a9e8e7b655fc99a4ad7f83f2e7becf
-    md5: db42c2ff03b58dbce1d66c910553c599
-work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198801010000-198812312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/vas/gr/v20190429/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198801010000-198812312100.nc
-  hashes:
-    binhash: c300fb29c0bd6c4ae159fcbd4f876694
-    md5: d107efccaeeb28cd13fd46274dc839a1
-work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198901010000-198912312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/vas/gr/v20190429/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_198901010000-198912312100.nc
-  hashes:
-    binhash: 846f99d32de7c27704ffcf9a3070bea0
-    md5: 0666a7b4c1fd85e6f5b043e3defc29bb
-work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199001010000-199012312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/vas/gr/v20190429/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199001010000-199012312100.nc
-  hashes:
-    binhash: 093ba15e07b8ed844acaa6c85b56e8d8
-    md5: 311bb85b5c2c287ba63ed8dad582cc62
-work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199101010000-199112312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/vas/gr/v20190429/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199101010000-199112312100.nc
-  hashes:
-    binhash: a6d1319669e7edf32f9d121f70a6bea1
-    md5: 187a3f9011352bf632d257326ecb8528
-work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199201010000-199212312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/vas/gr/v20190429/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199201010000-199212312100.nc
-  hashes:
-    binhash: d6b2a1e888daf6b3c47a4463557f11ac
-    md5: 9c6e60b0bba5f8642ed2a058750aa072
-work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199301010000-199312312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/vas/gr/v20190429/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199301010000-199312312100.nc
-  hashes:
-    binhash: 280f71dc0150232c8e7ad5bffd1e86d3
-    md5: 26657a654aca7e84e2a5244173936862
-work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199401010000-199412312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/vas/gr/v20190429/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199401010000-199412312100.nc
-  hashes:
-    binhash: dc8124edf27b116b8e8456b26f9d41b6
-    md5: fcdebb25b2b85f45529bb5e15c68623d
-work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199501010000-199512312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/vas/gr/v20190429/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199501010000-199512312100.nc
-  hashes:
-    binhash: d4380400f84abc328e16a6a3a9ce1417
-    md5: a344ec958616e168e5c7071afeb5c7b7
-work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199601010000-199612312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/vas/gr/v20190429/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199601010000-199612312100.nc
-  hashes:
-    binhash: a36efebc8a946572dad9addd17eaa816
-    md5: 71b72e35615751eaae8fa32116e6d89d
-work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199701010000-199712312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/vas/gr/v20190429/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199701010000-199712312100.nc
-  hashes:
-    binhash: c11437ded75eda56792420d1b0e33c50
-    md5: 912db46ddb7bb9a02d76c2be71703b9d
-work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199801010000-199812312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/vas/gr/v20190429/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199801010000-199812312100.nc
-  hashes:
-    binhash: a2205019a3ebf2c44c0ae2c356b468bc
-    md5: 01f712eaebb7841b1a8e796adc5b33e2
-work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199901010000-199912312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/vas/gr/v20190429/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_199901010000-199912312100.nc
-  hashes:
-    binhash: 46de049283775377ba5d57acd5f620d3
-    md5: 3912a4b215df3320324cdebfb7e7513f
-work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200001010000-200012312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/vas/gr/v20190429/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200001010000-200012312100.nc
-  hashes:
-    binhash: 8a49f1ba36d152313eec26f4f06af23d
-    md5: 0745dec78a93e1f3488587cd050ff486
-work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200101010000-200112312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/vas/gr/v20190429/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200101010000-200112312100.nc
-  hashes:
-    binhash: 6db51ad265f0484a117d1e87e59b9fa9
-    md5: 82b1b88df183529963f1657a9aaa4766
-work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200201010000-200212312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/vas/gr/v20190429/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200201010000-200212312100.nc
-  hashes:
-    binhash: 93959cde9c71f5474a798214c9585c13
-    md5: d662e64b0bfb54c3794bd9dbb4d3f31f
-work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200301010000-200312312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/vas/gr/v20190429/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200301010000-200312312100.nc
-  hashes:
-    binhash: 9ecb459e4cf040a4681d3a60056aff22
-    md5: fdc2192c0c33e9563b39d3c871688779
-work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200401010000-200412312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/vas/gr/v20190429/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200401010000-200412312100.nc
-  hashes:
-    binhash: 04b8691cc7049a2bbc95fe5d337dee76
-    md5: c78cd603799af1722ddac97015baa27d
-work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200501010000-200512312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/vas/gr/v20190429/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200501010000-200512312100.nc
-  hashes:
-    binhash: 6aa2fca7cc7896766649a4980087ea0f
-    md5: b837ae6bdb1acfe3f74284d415ddc143
-work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200601010000-200612312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/vas/gr/v20190429/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200601010000-200612312100.nc
-  hashes:
-    binhash: b0bd5d4a9ca57e201844047962e469cd
-    md5: b8b20b2ab2469e92221afd89a47301fc
-work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200701010000-200712312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/vas/gr/v20190429/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200701010000-200712312100.nc
-  hashes:
-    binhash: 67a06f5fa0c2e0ff8efe5ca14a25641b
-    md5: a570bf5208c6250492fd56713804a270
-work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200801010000-200812312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/vas/gr/v20190429/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200801010000-200812312100.nc
-  hashes:
-    binhash: 0d757590d89e5d9fd9ea7fdd43ca37e8
-    md5: 587eb63bbeb9d04ffb73af653b8b8f25
-work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200901010000-200912312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/vas/gr/v20190429/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_200901010000-200912312100.nc
-  hashes:
-    binhash: 6f84f7a245bd828f5b5aed43514c823c
-    md5: 04b8172af5f31112b06235ac32b78487
-work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201001010000-201012312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/vas/gr/v20190429/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201001010000-201012312100.nc
-  hashes:
-    binhash: 2601229f4ba045698a2b7f9470782f9d
-    md5: 5603fd2c82b0f7a6b6f0c93b0dbea066
-work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201101010000-201112312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/vas/gr/v20190429/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201101010000-201112312100.nc
-  hashes:
-    binhash: c717c815f18ecaabaa01681e3f709a1d
-    md5: 497230e268dfa4767c6b30f443315902
-work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201201010000-201212312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/vas/gr/v20190429/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201201010000-201212312100.nc
-  hashes:
-    binhash: 75ba41703dc3b91e3e4358310b8a2b37
-    md5: f7bbb9b4c29028f863467b3dfba4a5d1
-work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201301010000-201312312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/vas/gr/v20190429/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201301010000-201312312100.nc
-  hashes:
-    binhash: ebffde84d0b908f33f28f68bb36b15b8
-    md5: 5ec419b37c7cb897e59db8a78c1e8411
-work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201401010000-201412312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/vas/gr/v20190429/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201401010000-201412312100.nc
-  hashes:
-    binhash: 5ca1d749898d5b8160e1f2d87fe9975f
-    md5: cb6d1d597c60a921bd77cdf95c693756
-work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201501010000-201512312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/vas/gr/v20190429/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201501010000-201512312100.nc
-  hashes:
-    binhash: 158e4500a4fc4e652c0e2f4294083317
-    md5: 6b3f2a45e1726d0f413ee544856040cf
-work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201601010000-201612312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/vas/gr/v20190429/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201601010000-201612312100.nc
-  hashes:
-    binhash: e4e193e82ca2e5714717fea79d5657ab
-    md5: 4e42b2e7833ffedc460d03ec05fa1adc
-work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201701010000-201712312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/vas/gr/v20190429/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201701010000-201712312100.nc
-  hashes:
-    binhash: d472f4f3d031ae55ae36a60a95f822c0
-    md5: 93a327f3d3c4a44bbac963d8995e7b2a
-work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201801010000-201812312100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/vas/gr/v20190429/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201801010000-201812312100.nc
-  hashes:
-    binhash: e682da20a0898e6a75e46276c1f4df61
-    md5: 9df926d557e339b6abdb7a046451b9c4
-work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201901010000-201901052100.nc:
-  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6/OMIP/MRI/MRI-JRA55-do-1-4-0/atmos/3hrPt/vas/gr/v20190429/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-4-0_gr_201901010000-201901052100.nc
-  hashes:
-    binhash: 987ff85784eff1316d6929f631fe1426
-    md5: b0e514bfac0d9dfbf538d36b8ecd17f9
+work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_195801010130-195812312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_195801010130-195812312230.nc
+  hashes:
+    binhash: 4160c0e568c1cea6ed44be7e2f993a67
+    md5: 1162705075c4f16c4ff535705bfb2e99
+work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_195901010130-195912312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_195901010130-195912312230.nc
+  hashes:
+    binhash: 51055fe95239a9817effa638b46ff51d
+    md5: dcb57b99c91ad0285e7a7238990878e8
+work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196001010130-196012312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196001010130-196012312230.nc
+  hashes:
+    binhash: 75b0c808e61c2e758ef0dc52d15e24e3
+    md5: b5f6625c0fab64dadd9aa04766277589
+work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196101010130-196112312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196101010130-196112312230.nc
+  hashes:
+    binhash: 9e033afffe06fc0811222641130c51d2
+    md5: d5cc924ca388b4b21814dc02503be38f
+work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196201010130-196212312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196201010130-196212312230.nc
+  hashes:
+    binhash: 056e81fdbce79f989d528348ac10e0f4
+    md5: 4a2cf183f9611a22e0e0cbac2b4309c5
+work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196301010130-196312312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196301010130-196312312230.nc
+  hashes:
+    binhash: 8185fdecd84296b45129c48d2a4a480c
+    md5: 5a380562f2302c850222980e4ec30525
+work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196401010130-196412312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196401010130-196412312230.nc
+  hashes:
+    binhash: 6125d1dd82ee039d52de269b429e9b69
+    md5: 84a43d82a3158dee005ca4c78113403d
+work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196501010130-196512312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196501010130-196512312230.nc
+  hashes:
+    binhash: e0c4e537e449e66f55ebf42138bf1e90
+    md5: 9ce52bf6d672b7dfc1efdc44214cc64a
+work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196601010130-196612312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196601010130-196612312230.nc
+  hashes:
+    binhash: 7754b7a6d32d2d59486a09e7518dac26
+    md5: dc180d82fb6f72468fb9e45e999e77b2
+work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196701010130-196712312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196701010130-196712312230.nc
+  hashes:
+    binhash: e821c422280df6a286b20a37859f17d1
+    md5: 49df2a0dff62efd4e28ac0b6c74c29f6
+work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196801010130-196812312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196801010130-196812312230.nc
+  hashes:
+    binhash: fe007f6d06720bcf7df19562c46d9a0a
+    md5: 433694bd1aa7339a46eadd7453f992aa
+work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196901010130-196912312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196901010130-196912312230.nc
+  hashes:
+    binhash: 7ca0bbb5f21670b516538e77f13a49e2
+    md5: 2b4e22ffbb1f1245df93e2a0d52b7a23
+work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197001010130-197012312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197001010130-197012312230.nc
+  hashes:
+    binhash: 56c38b7ed2277825ae8e3618c712d8ce
+    md5: 57787e2e8c81b64e7cfdd4bff25145c5
+work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197101010130-197112312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197101010130-197112312230.nc
+  hashes:
+    binhash: 4aebcdb53b112f10e77a6a44cdfb47bf
+    md5: 175f92cd734a8c65e8df4635e43e32f4
+work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197201010130-197212312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197201010130-197212312230.nc
+  hashes:
+    binhash: 8f368dcab7a3921d04f96fe9e36f9af9
+    md5: 0d0f053d3350c8b40b904903bace8e94
+work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197301010130-197312312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197301010130-197312312230.nc
+  hashes:
+    binhash: 02018c977179290e1d496a8071b6d2ff
+    md5: fa5968624f019ed1796ba5dd9b0f27dc
+work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197401010130-197412312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197401010130-197412312230.nc
+  hashes:
+    binhash: 2da8a72ecc50b27051815778adcd1d82
+    md5: 186f4a85b2940558a2808e3d866ce569
+work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197501010130-197512312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197501010130-197512312230.nc
+  hashes:
+    binhash: f73a20c7b8965c23fb91f0ab9b54ce07
+    md5: 182f4aacce7d2bdac55f7a73dbfccb4a
+work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197601010130-197612312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197601010130-197612312230.nc
+  hashes:
+    binhash: 9b9daedc2c59f4042e5ecae105494363
+    md5: 19daf7b736b869bf530204b7903a7197
+work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197701010130-197712312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197701010130-197712312230.nc
+  hashes:
+    binhash: c03a50ba3ea474556cc00a3cbaa66fcb
+    md5: 319cfc51f9b71fc5b05717655e985b67
+work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197801010130-197812312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197801010130-197812312230.nc
+  hashes:
+    binhash: 4e0c62d56013cf42b52e55812d348a6b
+    md5: 5b87b8d1358beaad02b7613813d4ded8
+work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197901010130-197912312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197901010130-197912312230.nc
+  hashes:
+    binhash: e910586581a92ecada892dd35bc67b08
+    md5: e3857823a484bf24fec89089d49627ed
+work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198001010130-198012312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198001010130-198012312230.nc
+  hashes:
+    binhash: b754d4f53ffb30caddd778082b620e8c
+    md5: d39ab5f794d1117980936b6ac06336b5
+work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198101010130-198112312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198101010130-198112312230.nc
+  hashes:
+    binhash: 18f19c08143c007f0face43f463854a4
+    md5: 03bffb168c331966a381386124123b45
+work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198201010130-198212312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198201010130-198212312230.nc
+  hashes:
+    binhash: e856efd113400621f3cda242983d8414
+    md5: a69b2682dc5ec25cf46dc4955d2e9442
+work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198301010130-198312312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198301010130-198312312230.nc
+  hashes:
+    binhash: fa6c0f79d1b13f2ac367c7a2408af7ae
+    md5: bed3cac9f4d3df6a5b0fad485be5a2f0
+work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198401010130-198412312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198401010130-198412312230.nc
+  hashes:
+    binhash: 315fd40eafd793dfa7ea4214c5abb991
+    md5: ef308da4c0d4138649e93f142f46115a
+work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198501010130-198512312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198501010130-198512312230.nc
+  hashes:
+    binhash: 3431651e58626694b7601eb678414506
+    md5: d88ff97eab582848799b40a4888d0c1e
+work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198601010130-198612312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198601010130-198612312230.nc
+  hashes:
+    binhash: 1b899d012db6720b9605124ec8bab5f8
+    md5: 72c47153db4e5d97b685c3e6edd14649
+work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198701010130-198712312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198701010130-198712312230.nc
+  hashes:
+    binhash: 94c0a52dbde4112c8aa3e558be469aa5
+    md5: f6bd2cef4d858643dd9911dc1a0710f6
+work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198801010130-198812312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198801010130-198812312230.nc
+  hashes:
+    binhash: df1a1af6a4b120523190e250fc9f1e7b
+    md5: 97fc1699c61a796a8c25a99e37d6c089
+work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198901010130-198912312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198901010130-198912312230.nc
+  hashes:
+    binhash: 40f72da11862b37e22318cdd030199f3
+    md5: 5bd33d4c7961d06800d13020cc5a2b1b
+work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199001010130-199012312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199001010130-199012312230.nc
+  hashes:
+    binhash: 57b85ea3a92238653d3a8bd040222ab2
+    md5: 66329df232fc1eca05cee32a6aef7550
+work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199101010130-199112312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199101010130-199112312230.nc
+  hashes:
+    binhash: 477fb21fde7f3dc8bb6d4f578a786c76
+    md5: d18c3adb414a37da46fdcd6192ae1160
+work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199201010130-199212312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199201010130-199212312230.nc
+  hashes:
+    binhash: 5451687b40e12b46b0843a14fc2797c1
+    md5: cd589b12136bb6dcc095b4e482eacc6c
+work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199301010130-199312312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199301010130-199312312230.nc
+  hashes:
+    binhash: 5a736c375b6e61776ec2597dda198901
+    md5: ef1c3e9ac55bc250d3f5225dba6a5ae4
+work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199401010130-199412312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199401010130-199412312230.nc
+  hashes:
+    binhash: 56632447509d58dc9caeab6b79b25d75
+    md5: 1774f63a266c36d5fd598788bd44da8b
+work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199501010130-199512312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199501010130-199512312230.nc
+  hashes:
+    binhash: be01eccc1c940e4a8c0fb1c408414790
+    md5: 04bc35477fc80e6509acb3dda6bfe5e2
+work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199601010130-199612312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199601010130-199612312230.nc
+  hashes:
+    binhash: 45f370f8fbe36ce2fc90de8064b7d208
+    md5: 757a127a2cd89f82bb0248299683de52
+work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199701010130-199712312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199701010130-199712312230.nc
+  hashes:
+    binhash: 8f80dba727c569d39e595b5ba1af65e5
+    md5: 999dd89fa9e5c5db52fefb069e5070ec
+work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199801010130-199812312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199801010130-199812312230.nc
+  hashes:
+    binhash: 09ef9ed4efebf52d7c8bae40b73bd4fa
+    md5: d37d18e52044e3c02294d26b63477a97
+work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199901010130-199912312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199901010130-199912312230.nc
+  hashes:
+    binhash: 646d78b1f2c8b699348d400efba2c776
+    md5: 9672f2fd3326705599ef2e0d4a85f6c9
+work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200001010130-200012312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200001010130-200012312230.nc
+  hashes:
+    binhash: e6cb2d77d17f07c11eb75894dca209b7
+    md5: 81eea8819d17a9f83886964c3528ab67
+work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200101010130-200112312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200101010130-200112312230.nc
+  hashes:
+    binhash: f0f1ef38e37bb9bfb9a7e62adf5a6f29
+    md5: f49018435d8a40e685aad07cd4e2c919
+work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200201010130-200212312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200201010130-200212312230.nc
+  hashes:
+    binhash: 13b53c6bc9e8c8a492c76659cf4c2685
+    md5: 270cf2500d3cb754372fab7007704e26
+work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200301010130-200312312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200301010130-200312312230.nc
+  hashes:
+    binhash: 9d062bb605f088292d3d470f81aa2d2c
+    md5: 314f13ee6cc400aba42e1ce02d150923
+work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200401010130-200412312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200401010130-200412312230.nc
+  hashes:
+    binhash: 6009539f1495985bd0c8cca67782e793
+    md5: 21c286dd88b6018815d891788b3a3a77
+work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200501010130-200512312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200501010130-200512312230.nc
+  hashes:
+    binhash: 30de1d67161c067879e065686f3d31f6
+    md5: 5ee545255d764a77ce21237a931f8c31
+work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200601010130-200612312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200601010130-200612312230.nc
+  hashes:
+    binhash: 664177e391ea1153d9dd49855440704e
+    md5: 4a2b0207c0120aa76367cb49b8fb0ee9
+work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200701010130-200712312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200701010130-200712312230.nc
+  hashes:
+    binhash: 9ba2441f2ee15931f5c4fa2c97e027f1
+    md5: fee4fb06d78ac04771e2be0c16c2e657
+work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200801010130-200812312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200801010130-200812312230.nc
+  hashes:
+    binhash: d11f20a9293f7a64e09c9e41c19bc654
+    md5: c8f023cc553d6ee96a45939d51facba6
+work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200901010130-200912312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200901010130-200912312230.nc
+  hashes:
+    binhash: 629a4500c19598624a799ff87dfe3e62
+    md5: a300bdc55d7036dc17b25554057c5ee5
+work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201001010130-201012312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201001010130-201012312230.nc
+  hashes:
+    binhash: c3cd0604b48bc9e5f209bdba880761b3
+    md5: d35ef2fa5bd0a7e34e1217d976750ea3
+work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201101010130-201112312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201101010130-201112312230.nc
+  hashes:
+    binhash: 369235b8ebbc338cb8f0e505a22539be
+    md5: 3baf32b64b6493180e09c6f29422e43f
+work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201201010130-201212312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201201010130-201212312230.nc
+  hashes:
+    binhash: 9a94c096ce6f95938f37617952e1a920
+    md5: 6cf7ed41b8d468cb28203543d911025a
+work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201301010130-201312312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201301010130-201312312230.nc
+  hashes:
+    binhash: 98e991577c63e5bef54901e16cb2e422
+    md5: 978f2c30c4ccf5f0ba2f7127cbdb5ae5
+work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201401010130-201412312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201401010130-201412312230.nc
+  hashes:
+    binhash: 1e9356fc189eb92020a4c8ba09d866ab
+    md5: 3f51b5720b3415a8cf777115f5777d08
+work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201501010130-201512312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201501010130-201512312230.nc
+  hashes:
+    binhash: 03d7f87b2dc64603ae1cc336b0e0ec17
+    md5: 12fcaa95e84b8c84acb769a8337a9d72
+work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201601010130-201612312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201601010130-201612312230.nc
+  hashes:
+    binhash: a1241396c0a0fb05b52743741cf367ed
+    md5: 3d29f133c800dccb49502031ff42fe01
+work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201701010130-201712312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201701010130-201712312230.nc
+  hashes:
+    binhash: d77af6567ba170bc4e365b0ba23d7b2c
+    md5: cc4b227d08e78af6bca7c0d03c21c15b
+work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201801010130-201812312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201801010130-201812312230.nc
+  hashes:
+    binhash: f79d4f33e86478881cfe3f9a3da171e1
+    md5: 4c68873385ec126515894ed20376576b
+work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201901010130-201912312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201901010130-201912312230.nc
+  hashes:
+    binhash: da3e5682b31447dc1aa8b514240cc338
+    md5: 50951a62569b1032edbc85c371228592
+work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202001010130-202012312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202001010130-202012312230.nc
+  hashes:
+    binhash: 7f30ee9df53d6a13e055bd1a9f234990
+    md5: 3e40d6e080622f045ab11329f4980ab0
+work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202101010130-202112312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202101010130-202112312230.nc
+  hashes:
+    binhash: 24e82fd75ab6bbbf26a21d7a9ef0e879
+    md5: 1295bb25e8045dcea509213fdf6e8207
+work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202201010130-202212312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202201010130-202212312230.nc
+  hashes:
+    binhash: 7677d33d240a24811e260ee4cd48664f
+    md5: 4600ed0370b1365a32e5c44695dc2461
+work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202301010130-202312312230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202301010130-202312312230.nc
+  hashes:
+    binhash: 3b7e907e93bef15f41e07e8c10816dce
+    md5: 657a7343a5391d40e098d8135cfa8b9f
+work/atmosphere/INPUT/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202401010130-202402012230.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hr/rsds/gr/v20240531/rsds_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202401010130-202402012230.nc
+  hashes:
+    binhash: 687c148425a1a5a120693bfb27423127
+    md5: bc7ed30ab9ce2709ec256fc5c7ba9f73
+work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_195801010000-195812312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_195801010000-195812312100.nc
+  hashes:
+    binhash: 8f296602a5bda607fe3f3613a8872cb6
+    md5: 09ba434f0e6cba64f65200fad4f0014e
+work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_195901010000-195912312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_195901010000-195912312100.nc
+  hashes:
+    binhash: 500916535d0f4d553321e2360789163b
+    md5: 5f9bd05b5363fc7368549ca934a6cbea
+work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196001010000-196012312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196001010000-196012312100.nc
+  hashes:
+    binhash: 2fba4833018b6af1dec383d83013cc68
+    md5: 06a49bc17ededcc91f1365f74020a0b4
+work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196101010000-196112312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196101010000-196112312100.nc
+  hashes:
+    binhash: a882bf10332d3aaff9d7dd5b18d4a3d1
+    md5: 499109ada5bd79dffaf88967501c4ff7
+work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196201010000-196212312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196201010000-196212312100.nc
+  hashes:
+    binhash: e3d2fecc22f40288fdbc6de2b875fdaf
+    md5: 7602ddf9652d347faa5a31501294f816
+work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196301010000-196312312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196301010000-196312312100.nc
+  hashes:
+    binhash: 0f7bdc9741d013984f03cb4431168c81
+    md5: ea89eb4cc6e646ab8884c7c4361f5497
+work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196401010000-196412312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196401010000-196412312100.nc
+  hashes:
+    binhash: 42682dc37b824909197531266553245f
+    md5: 53147613bb0e07d353a8297b586d506b
+work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196501010000-196512312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196501010000-196512312100.nc
+  hashes:
+    binhash: ede89a62cb9f406a930cdb9e934c4e51
+    md5: e8977203f2c55837cbf5f6888e18d446
+work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196601010000-196612312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196601010000-196612312100.nc
+  hashes:
+    binhash: 5cb87c37a68103c30283845fd3f61f2d
+    md5: 0949208589d91ce7da2675baebfa7c21
+work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196701010000-196712312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196701010000-196712312100.nc
+  hashes:
+    binhash: f70b28fac010ee15e674e58776d7ba17
+    md5: fe59f09d7026968fd898b0f46be4234e
+work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196801010000-196812312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196801010000-196812312100.nc
+  hashes:
+    binhash: c023e4677e0893bcf955b50bd2e8570c
+    md5: 772c9a2392ed3d8d1e0571c169578ef8
+work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196901010000-196912312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196901010000-196912312100.nc
+  hashes:
+    binhash: 8b5bec30ba60a80b70e8647789dbb5e0
+    md5: f0b22d8a4d09a69abc7b55c1036e78f4
+work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197001010000-197012312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197001010000-197012312100.nc
+  hashes:
+    binhash: 07d80668694f61160717a7976fef20ec
+    md5: 751a694168076c0af1540bd71c70e26d
+work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197101010000-197112312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197101010000-197112312100.nc
+  hashes:
+    binhash: 26e6b7de0ef8f7484182e64b306b80cf
+    md5: 306116ba55f5be7e3dc533b96248e69a
+work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197201010000-197212312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197201010000-197212312100.nc
+  hashes:
+    binhash: 95f1c3fa6389f5c94caff10a93bd91bc
+    md5: 7cf0ce3a6b49948a3fd765908645f9a4
+work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197301010000-197312312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197301010000-197312312100.nc
+  hashes:
+    binhash: 4595c3e7dea3adbc222bd2bdd30f1c72
+    md5: 4c02fda4f9da8e1caa3ba84c19e3a0fd
+work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197401010000-197412312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197401010000-197412312100.nc
+  hashes:
+    binhash: e1ccd87483da028f6e35559f8c20c033
+    md5: b9ba86f65d094c9b665bc457b5027380
+work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197501010000-197512312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197501010000-197512312100.nc
+  hashes:
+    binhash: b3f376c2c6d471efaae9deb160560cbf
+    md5: 3ec67fc692fcf25891c83da000eca4b2
+work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197601010000-197612312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197601010000-197612312100.nc
+  hashes:
+    binhash: e07383b71f228242cf0d85ebc8e8ff70
+    md5: 6c04513a019669355b14620b8644123a
+work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197701010000-197712312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197701010000-197712312100.nc
+  hashes:
+    binhash: e3422d2544017b9c60eaf195c5883a19
+    md5: 44b597d341f5758135baf41175a35aa5
+work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197801010000-197812312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197801010000-197812312100.nc
+  hashes:
+    binhash: 1f66fa5e424321c8880f51421a9a4b12
+    md5: 3ac4efb7da8806b30cbd9c8b988a79bb
+work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197901010000-197912312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197901010000-197912312100.nc
+  hashes:
+    binhash: 6fb4672216f1a310c2296a7b0ace40f0
+    md5: 0fb7c1bc4bd0c27d729654ccdb368389
+work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198001010000-198012312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198001010000-198012312100.nc
+  hashes:
+    binhash: 1d06dbf181140b4a93d4da6811cd12c8
+    md5: 109df01bd4da1198833bfaa5f4f7e834
+work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198101010000-198112312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198101010000-198112312100.nc
+  hashes:
+    binhash: 9544693c75eda4fcc627a1f34a4db236
+    md5: 9aac1f99be60400a981132dd83ed0537
+work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198201010000-198212312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198201010000-198212312100.nc
+  hashes:
+    binhash: 77871cd71f1a85169fbf35a012b681e0
+    md5: a7f0844a02275507f32e6fe2ecb59c19
+work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198301010000-198312312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198301010000-198312312100.nc
+  hashes:
+    binhash: 7f8088fbfd6ef04392ed83aa89cc6470
+    md5: fd4b53447156d74c0701d286a75ebdea
+work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198401010000-198412312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198401010000-198412312100.nc
+  hashes:
+    binhash: 43aad87903281fc8fb8646d6ca9f7076
+    md5: 76ab93c2ffeb36fafb6f84d9ca448e6b
+work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198501010000-198512312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198501010000-198512312100.nc
+  hashes:
+    binhash: 7fa8d4ad57c00e66fab04ea714f213f9
+    md5: 31d0202c0cbbc23624912013d8a2325a
+work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198601010000-198612312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198601010000-198612312100.nc
+  hashes:
+    binhash: a1d6caecc5a71f0f3312976d320a1c27
+    md5: b6340841b1296c5082b64df0b74d1c09
+work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198701010000-198712312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198701010000-198712312100.nc
+  hashes:
+    binhash: c95342b59b08ca97bd705facdf4a3a34
+    md5: 3cc08cee947fe41620f95f35d09146da
+work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198801010000-198812312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198801010000-198812312100.nc
+  hashes:
+    binhash: 77d5284b3060d49e6371d68cb644c7ba
+    md5: 70863535dbb88ffe436bb03611769d5e
+work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198901010000-198912312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198901010000-198912312100.nc
+  hashes:
+    binhash: 37e80e8fedeba8f60cf5bda6ba16d674
+    md5: 8ac784c1418c5a9df0a8a5f4609ac136
+work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199001010000-199012312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199001010000-199012312100.nc
+  hashes:
+    binhash: e52a60d21aaebf633898b5d618adf19f
+    md5: 5048a0a794c43c54849e892f615a3e63
+work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199101010000-199112312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199101010000-199112312100.nc
+  hashes:
+    binhash: 3d74ba681dc5e0914c3a7dfa8131473d
+    md5: f83a40dedb0725d303f0ca11859a0258
+work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199201010000-199212312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199201010000-199212312100.nc
+  hashes:
+    binhash: e006562953ccc63aa176d4eacee23fb4
+    md5: 6c46307b08d2e1812b14f21c37bddd96
+work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199301010000-199312312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199301010000-199312312100.nc
+  hashes:
+    binhash: 770d306bb5be3a2d3a1793b022500f10
+    md5: 73de5445b4b76d52f24b8f0cf8df052c
+work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199401010000-199412312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199401010000-199412312100.nc
+  hashes:
+    binhash: a415c48a7fe93889a6046b5c13dd7c15
+    md5: d1018b9fd915aaf0d1d35d029931df90
+work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199501010000-199512312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199501010000-199512312100.nc
+  hashes:
+    binhash: 5a2f13b12fde3e73e37ebd6f4635439c
+    md5: a56cf2ae1b513ef71727bce92e116cdc
+work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199601010000-199612312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199601010000-199612312100.nc
+  hashes:
+    binhash: ed5c25c12537f81ff821fbd5792772fa
+    md5: 4818bc571e467e12d17d2e67a2050580
+work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199701010000-199712312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199701010000-199712312100.nc
+  hashes:
+    binhash: 910601fefb937e02e09cf5903c0b8fab
+    md5: 595227d840000b716a38a9c4f2529e4f
+work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199801010000-199812312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199801010000-199812312100.nc
+  hashes:
+    binhash: 87fadf59818264a1675fbc11b0a51917
+    md5: 3c75c1ae359b4710fd93658fe9740ee5
+work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199901010000-199912312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199901010000-199912312100.nc
+  hashes:
+    binhash: cad7c7fe1ad296859a4c327f6d5d5936
+    md5: 6637ef7bd474abdc31485b656d83581f
+work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200001010000-200012312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200001010000-200012312100.nc
+  hashes:
+    binhash: 89ae164bc18ec4478248c54cd0c5d334
+    md5: da3ad7aeace4168eb750ced799fe77a7
+work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200101010000-200112312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200101010000-200112312100.nc
+  hashes:
+    binhash: 66b06651b1c1fa37540c41625534d02a
+    md5: e3b27407185979027e8debda46903486
+work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200201010000-200212312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200201010000-200212312100.nc
+  hashes:
+    binhash: 295dc028550bafe54f07a6fc6dbaae92
+    md5: eb6825721068134eeaab14d269f91e66
+work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200301010000-200312312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200301010000-200312312100.nc
+  hashes:
+    binhash: 0700c9aaa1bd376802117d4c07146056
+    md5: 6f09748e7f4719be877ecd67dff62316
+work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200401010000-200412312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200401010000-200412312100.nc
+  hashes:
+    binhash: b4ca146c4ef74a8cef3f6a09506aed59
+    md5: e5c5348063c018d8fc2afdaf7003e34a
+work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200501010000-200512312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200501010000-200512312100.nc
+  hashes:
+    binhash: 89563132d9bc227b28c5ee2539818a81
+    md5: e7605c9e1ec63e3e3bfb2cd71469205e
+work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200601010000-200612312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200601010000-200612312100.nc
+  hashes:
+    binhash: 61f4e0e8b4ac27d88cc8585d2f155f81
+    md5: 48190e0187f1f10fa0c495e1c4e27bbc
+work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200701010000-200712312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200701010000-200712312100.nc
+  hashes:
+    binhash: 1839e7036a885e8f9b99c47f770d1832
+    md5: dfcaefe12d6ff667d101f6b93f5ba831
+work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200801010000-200812312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200801010000-200812312100.nc
+  hashes:
+    binhash: 041a6b6976aec0f1b82e38599959087a
+    md5: 29044880e67fd9d39b3b325741a227eb
+work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200901010000-200912312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200901010000-200912312100.nc
+  hashes:
+    binhash: 785e17000d586a7220982e7d24da9ac4
+    md5: 0c023eb9ed2c2988928bdb0b7be8df0b
+work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201001010000-201012312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201001010000-201012312100.nc
+  hashes:
+    binhash: 0372954d1e9134a392df1a2f7dc714f5
+    md5: c15123aec1c3d518b322d4c49cc43182
+work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201101010000-201112312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201101010000-201112312100.nc
+  hashes:
+    binhash: 36e438b76edadd0ebcbbfb87fe923257
+    md5: 17d871ce52ee049c9e5e77136f6d9758
+work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201201010000-201212312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201201010000-201212312100.nc
+  hashes:
+    binhash: 069f866cbbceb1a0b5674025ca42f5e3
+    md5: dd08c9720d61b3d6b2bde4b1e5867879
+work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201301010000-201312312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201301010000-201312312100.nc
+  hashes:
+    binhash: 7e76697fa2ac781c938baa7bfda84f1b
+    md5: 4c32c7a5167e75964bdc0de0c4dc4ce5
+work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201401010000-201412312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201401010000-201412312100.nc
+  hashes:
+    binhash: 457eef13dc47b9a774828fcdd89992d8
+    md5: 3ce2dbebd48ba7ecdcf96ba41a9341a1
+work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201501010000-201512312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201501010000-201512312100.nc
+  hashes:
+    binhash: d7cfa146dd3ba528f12346354d21bdb9
+    md5: 694204d5120a15a11f23bc700278e521
+work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201601010000-201612312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201601010000-201612312100.nc
+  hashes:
+    binhash: 0df5314c78051d8a4e80f2809591702a
+    md5: a09a702587f9d21cc6f69b77aca43988
+work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201701010000-201712312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201701010000-201712312100.nc
+  hashes:
+    binhash: 816d1851239b1637ef56ced448a6334c
+    md5: 77341e2e53ea8300110382aaa82ca361
+work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201801010000-201812312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201801010000-201812312100.nc
+  hashes:
+    binhash: ad8b946db78568897ff8f9d196748529
+    md5: d7784ca194ac9a41912463486d91fed3
+work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201901010000-201912312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201901010000-201912312100.nc
+  hashes:
+    binhash: e7abe8f28f2cb6387328239a1d5a6b08
+    md5: c8a69bb0b2c6ff92726fabd44d17835f
+work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202001010000-202012312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202001010000-202012312100.nc
+  hashes:
+    binhash: 28eec7cc7673ff38a80c5b424d3ad8c4
+    md5: fe2a2107d247cd3e060d1446df1c1b93
+work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202101010000-202112312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202101010000-202112312100.nc
+  hashes:
+    binhash: 12daf5ba5229f5268467af6f45dd67bb
+    md5: 46465a4308e7e12f62ce3bdd42ccec43
+work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202201010000-202212312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202201010000-202212312100.nc
+  hashes:
+    binhash: 42efbd5c452eaea02154020b105e87a7
+    md5: 626a67d77f002d4a2d0b327b370acea3
+work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202301010000-202312312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202301010000-202312312100.nc
+  hashes:
+    binhash: 80838e9e4b1ed478b67652aeff9eb53d
+    md5: 9cb4a48a0550d1afac31834bdbdf4b81
+work/atmosphere/INPUT/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202401010000-202402012100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/tas/gr/v20240531/tas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202401010000-202402012100.nc
+  hashes:
+    binhash: a96d358e5a2c81023eb9c8bdf43e6474
+    md5: c354ed2ec9cfcbba9c4973aff7865e31
+work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_195801010000-195812312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_195801010000-195812312100.nc
+  hashes:
+    binhash: 3d71e934e6b8b4299fb87ae8b830a87a
+    md5: 7f96c94991b8cf9728fd905f5300a3ad
+work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_195901010000-195912312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_195901010000-195912312100.nc
+  hashes:
+    binhash: 6f2b9ab54cbeb50d6f16ad2be7a50ed3
+    md5: 09be8464de98d518df530f3cdb5c20cc
+work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196001010000-196012312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196001010000-196012312100.nc
+  hashes:
+    binhash: 57c1665984b750e91a0e30491bd6207c
+    md5: cb12bd789b095077be032f4542c92c24
+work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196101010000-196112312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196101010000-196112312100.nc
+  hashes:
+    binhash: 25663d5cfeaff87a77f9ec6ebb27c433
+    md5: d35f61d7aa47b04ac123a7f56178e36f
+work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196201010000-196212312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196201010000-196212312100.nc
+  hashes:
+    binhash: 05d2412c9e5ae1d370fe6be86c2165ad
+    md5: 1811ee730403e7e071f06fc57d6e3f60
+work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196301010000-196312312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196301010000-196312312100.nc
+  hashes:
+    binhash: 48a746115956a60310978942aa4c573a
+    md5: 7378d60b35a1beead8e2441e8205c3d5
+work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196401010000-196412312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196401010000-196412312100.nc
+  hashes:
+    binhash: 4396e721304e15130f0ed6013a1d75c1
+    md5: 60629f953e82673d9f5fd4cd5fdc2434
+work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196501010000-196512312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196501010000-196512312100.nc
+  hashes:
+    binhash: ca8bac1618432ef62788b3643ae29631
+    md5: afa53a236e58f4e8e747ef217717eb46
+work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196601010000-196612312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196601010000-196612312100.nc
+  hashes:
+    binhash: 2462d31c74fd2eb25ea81862308fd581
+    md5: 2c604369db5e0796afa70cac93d771d3
+work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196701010000-196712312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196701010000-196712312100.nc
+  hashes:
+    binhash: 464873f8650dfa4fec7461d302b8e60a
+    md5: e7b79ff249621d32bfe8c958c949ea1e
+work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196801010000-196812312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196801010000-196812312100.nc
+  hashes:
+    binhash: c97c91808cd6c7f1637d9943832d49d3
+    md5: 380b269e9cd7d987c0aad5d87463e216
+work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196901010000-196912312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196901010000-196912312100.nc
+  hashes:
+    binhash: a7480437ebb227f394e88a6a18a04052
+    md5: 8fdf774ed7a1e559aca70b8ef66edf34
+work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197001010000-197012312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197001010000-197012312100.nc
+  hashes:
+    binhash: f74c392aeff504f76cdf3534ab2a9f0e
+    md5: 5268b701309e382104b6814ffcfd8d5e
+work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197101010000-197112312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197101010000-197112312100.nc
+  hashes:
+    binhash: 32b84e6874ea96e575e3d384bb983371
+    md5: 68fb516433e8d921284ee6611d0db602
+work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197201010000-197212312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197201010000-197212312100.nc
+  hashes:
+    binhash: b2cb54a5dfcaaf079b5b8ecc68f7ea85
+    md5: 15323fa8cc769f1d1a37f74b175d25c0
+work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197301010000-197312312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197301010000-197312312100.nc
+  hashes:
+    binhash: 5996e311e99107df018576744ad0a1f1
+    md5: 928e547fd84602d19f6082f72ab2f234
+work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197401010000-197412312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197401010000-197412312100.nc
+  hashes:
+    binhash: 1fb23125f55e2454ffd4bd3660a902d7
+    md5: ccbee69ce9ebc8818e12433ef788ac73
+work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197501010000-197512312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197501010000-197512312100.nc
+  hashes:
+    binhash: 0f5cc00e5496926108f8bc30bc356c79
+    md5: af76306ffc29d44a6a341a188e89b7aa
+work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197601010000-197612312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197601010000-197612312100.nc
+  hashes:
+    binhash: 5580760371933f92bad9d8a95d97a131
+    md5: 5425ae80bd2db066dd0813ac9c666608
+work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197701010000-197712312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197701010000-197712312100.nc
+  hashes:
+    binhash: 13d8f92e5405093e18f8b34aa32d1413
+    md5: 1b3bbf717cbc6c3dbdbae118e745033a
+work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197801010000-197812312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197801010000-197812312100.nc
+  hashes:
+    binhash: c20cfdb98ca66775aa9a933fed8f96f5
+    md5: b47a0108eb805330fefdcbafc57d22c2
+work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197901010000-197912312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197901010000-197912312100.nc
+  hashes:
+    binhash: 32ec3f401dc5a8c79ea47037fda580bb
+    md5: 62193e67119f9b1097ca1c13ee8f2092
+work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198001010000-198012312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198001010000-198012312100.nc
+  hashes:
+    binhash: ecbc441596dd42894cd768f6f4a1949d
+    md5: 1577fc35e1631a79c26f618de854955e
+work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198101010000-198112312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198101010000-198112312100.nc
+  hashes:
+    binhash: d85ae076877ff3a4a8cdd35eb910e040
+    md5: c4e9667841f47524291efc1f5553c91c
+work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198201010000-198212312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198201010000-198212312100.nc
+  hashes:
+    binhash: fbf9fbb57c40939891ec27bbacb8bece
+    md5: 8a78b01941ce1566380d6f774c05ddb9
+work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198301010000-198312312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198301010000-198312312100.nc
+  hashes:
+    binhash: c36a43b91966aa53f77c67f6ccb7a859
+    md5: 4becb1991e91ca7c57adc1c62b403026
+work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198401010000-198412312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198401010000-198412312100.nc
+  hashes:
+    binhash: 97fa8ae651a0f3bc25f50b9b1cf41320
+    md5: 0175eaf50e3645ed4f3ab7c223207835
+work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198501010000-198512312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198501010000-198512312100.nc
+  hashes:
+    binhash: eceae1588dfdc6a1a5c46304a902d0c8
+    md5: 48e1071888c32adbbd62faf5a7e9ca54
+work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198601010000-198612312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198601010000-198612312100.nc
+  hashes:
+    binhash: c10e39539253405c052d4329917773bb
+    md5: d35165983ddc1589f8f8a83e4acaa143
+work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198701010000-198712312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198701010000-198712312100.nc
+  hashes:
+    binhash: 5bf03780122cf822154660a11d47e920
+    md5: 4c7606477ec386bba997499556d31c9c
+work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198801010000-198812312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198801010000-198812312100.nc
+  hashes:
+    binhash: c16802df8839055c394384374909cbb2
+    md5: 13b6ada5f329ca320d59beaf81085fe1
+work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198901010000-198912312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198901010000-198912312100.nc
+  hashes:
+    binhash: e7f5b53083e9bfcfe6a6c5815df0717b
+    md5: dd91db84b460e2a77dae80ed97cdef31
+work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199001010000-199012312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199001010000-199012312100.nc
+  hashes:
+    binhash: 388c2602d2ccd0238f4c4abb00336da8
+    md5: 8277735da5c3514f5f51b0270fc455c5
+work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199101010000-199112312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199101010000-199112312100.nc
+  hashes:
+    binhash: 4a40cfe28eaa8730ec958ac9d85bf907
+    md5: 3906a2cccee737ef78833dfce871eb18
+work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199201010000-199212312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199201010000-199212312100.nc
+  hashes:
+    binhash: a84eb9f616b9ce4bafd3f041c07759fd
+    md5: b6ab41d802d4308b27879989db815efb
+work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199301010000-199312312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199301010000-199312312100.nc
+  hashes:
+    binhash: 530b7a7043382d3df07d4353284aba2e
+    md5: f35f089de16645c9474879175183c0bf
+work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199401010000-199412312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199401010000-199412312100.nc
+  hashes:
+    binhash: 232fed4eb2e4cbf81202baeacb1895d1
+    md5: 674ad78c49762bece20e6661b316c21b
+work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199501010000-199512312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199501010000-199512312100.nc
+  hashes:
+    binhash: 2b9269fdae5a129ac02e61e19c2b509d
+    md5: 227a3f5e8d96c03cf213619da5aa32e2
+work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199601010000-199612312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199601010000-199612312100.nc
+  hashes:
+    binhash: 7ddaff51f0239e929e88e5709adb72f0
+    md5: af877295aef9979a27a71348d44007e9
+work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199701010000-199712312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199701010000-199712312100.nc
+  hashes:
+    binhash: 19178da8065f344531a83b59856a78bd
+    md5: bd0bd3f52703909eb1ed4fa338678582
+work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199801010000-199812312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199801010000-199812312100.nc
+  hashes:
+    binhash: 758c71aa0002b7ddf48c6fa0f89c82f0
+    md5: c4cb267660194158f6ef248b408563ca
+work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199901010000-199912312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199901010000-199912312100.nc
+  hashes:
+    binhash: 91f81ffec81f417bd8d2c54482da1bd2
+    md5: 5d90fc9701e8b33c57a666e4a67682ba
+work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200001010000-200012312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200001010000-200012312100.nc
+  hashes:
+    binhash: c7ba53f57cb022a2df63b7fe5a023a2d
+    md5: 891e9629bfbd69b2952ee94adaee739d
+work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200101010000-200112312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200101010000-200112312100.nc
+  hashes:
+    binhash: 4db4bfcfb038bdac94cbfbb1b18b7b31
+    md5: 4f5f9427d62c9853ecbea5ed2d6b4a85
+work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200201010000-200212312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200201010000-200212312100.nc
+  hashes:
+    binhash: dc3e7ef10e3124774afab758c55a874e
+    md5: 442e2e48c1207ab0453e0552a607a0ed
+work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200301010000-200312312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200301010000-200312312100.nc
+  hashes:
+    binhash: a24621d13669db9bdf27ebd2395c75e3
+    md5: 28565115b9181ef44316d4ad60324f7b
+work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200401010000-200412312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200401010000-200412312100.nc
+  hashes:
+    binhash: 177e280dbb2c825555cd6ccbbd493a7f
+    md5: c491f19d715f04dcbc2cc106e970e1a5
+work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200501010000-200512312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200501010000-200512312100.nc
+  hashes:
+    binhash: a88457bd9d2896baf1a12210c71f0303
+    md5: 824b1ffb3756fd5e1a36279f0db05f54
+work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200601010000-200612312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200601010000-200612312100.nc
+  hashes:
+    binhash: d428ae68f31a771f42dc9873d6c2a558
+    md5: 53051d02c0f16e030d97a9be0fd992f9
+work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200701010000-200712312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200701010000-200712312100.nc
+  hashes:
+    binhash: c6f8ef2bc24076dc9a1f67f87b4efec7
+    md5: 38be1a8a60ac7fcb1fc791f3788b2893
+work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200801010000-200812312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200801010000-200812312100.nc
+  hashes:
+    binhash: def2e87e7fd66f1688e54ede19f688ec
+    md5: 11d35f3f403402ef6229760ddab6b2a2
+work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200901010000-200912312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200901010000-200912312100.nc
+  hashes:
+    binhash: 4370663c9678ca8e812a0eb2763741a5
+    md5: 1ab76f7a57ee31e88c30602119e9b76f
+work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201001010000-201012312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201001010000-201012312100.nc
+  hashes:
+    binhash: ffcc793b12d42cc27eba2b855c819a08
+    md5: 7844fd99e9b92fa8d1030cc863aaf283
+work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201101010000-201112312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201101010000-201112312100.nc
+  hashes:
+    binhash: abe17d932abd93d32ea45bf72ceac74e
+    md5: 08e7175e2625f1f21b762b583c89872a
+work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201201010000-201212312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201201010000-201212312100.nc
+  hashes:
+    binhash: 2795dc7edc6c5bac6cbb760fed30b985
+    md5: 7a5b0dcbb00c37e4fc46014d5eb71d99
+work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201301010000-201312312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201301010000-201312312100.nc
+  hashes:
+    binhash: 82cd9158dfc48912f8a0f1e70916784d
+    md5: 288d0d5edfd7d616bfc99ec2382a8fcb
+work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201401010000-201412312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201401010000-201412312100.nc
+  hashes:
+    binhash: 9595e37d4c763a217e1f376d2d336a15
+    md5: b60422be277d1fa7e63ec922118ec53f
+work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201501010000-201512312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201501010000-201512312100.nc
+  hashes:
+    binhash: 68b9a4322ae8aae8da66f02bb04092cc
+    md5: 526a086de76c8db1208ab7d43b508e27
+work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201601010000-201612312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201601010000-201612312100.nc
+  hashes:
+    binhash: 208c8f90ac9f6cdd1e2f3b4d746b1c7e
+    md5: 3ff227e711ad54a554263c14013ed7eb
+work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201701010000-201712312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201701010000-201712312100.nc
+  hashes:
+    binhash: ec8abeb5d7c5c3061f6a8e3f97cd206e
+    md5: 59af7f4460449a86a89d375293aa4ec0
+work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201801010000-201812312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201801010000-201812312100.nc
+  hashes:
+    binhash: 3dc2144320494ab652a4a8f7a2cfb9a7
+    md5: 6b841f972ef40ea475fdae52648c8adf
+work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201901010000-201912312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201901010000-201912312100.nc
+  hashes:
+    binhash: dc8c4a9a96e7a3138fb3cfbeb60423a7
+    md5: 5add043c28075d4a06439593ca76b717
+work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202001010000-202012312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202001010000-202012312100.nc
+  hashes:
+    binhash: e07f942b550f3a9b81af7780002f043d
+    md5: 83605f2a348a30559a3048cda10cfbc3
+work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202101010000-202112312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202101010000-202112312100.nc
+  hashes:
+    binhash: 2ebde6a10ed03128413397e11b2a60f8
+    md5: 249114448974770e28799552f8255a36
+work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202201010000-202212312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202201010000-202212312100.nc
+  hashes:
+    binhash: 79292024ceec76a954726c3d1a167b13
+    md5: 746fe8bb2c2fb609c24fb3e6218c4a0c
+work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202301010000-202312312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202301010000-202312312100.nc
+  hashes:
+    binhash: 983a8ec4096b63c2c361500752fff7c8
+    md5: 8584389a475a8bb9e0ac6ae0ab948eaf
+work/atmosphere/INPUT/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202401010000-202402012100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/uas/gr/v20240531/uas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202401010000-202402012100.nc
+  hashes:
+    binhash: 9b51345be3b2315c8311e2a722770f74
+    md5: 3590467a9c339f3818b275fcfca20796
+work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_195801010000-195812312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_195801010000-195812312100.nc
+  hashes:
+    binhash: 144af15389bc9e1d96c9a909d29b6806
+    md5: 9c80a1fd5137b784934efd11d9a1dfcf
+work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_195901010000-195912312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_195901010000-195912312100.nc
+  hashes:
+    binhash: e055ef18d957ec25062ce1b99c38aa53
+    md5: f8fab674988934f77599d3521cb17076
+work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196001010000-196012312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196001010000-196012312100.nc
+  hashes:
+    binhash: ea36222f3f61b8993c549cbc05584adf
+    md5: 8e46a42114b43d8b8d4e919f39b32b26
+work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196101010000-196112312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196101010000-196112312100.nc
+  hashes:
+    binhash: 71bbb717b9479341f41459dec52daf04
+    md5: 429239dc2655116dae572667b75caf21
+work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196201010000-196212312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196201010000-196212312100.nc
+  hashes:
+    binhash: b649a6449e1ac21de44db8f58dcc32b6
+    md5: 5da1f4e659b7cf68d2e8ff87ea8f9c1c
+work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196301010000-196312312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196301010000-196312312100.nc
+  hashes:
+    binhash: 911c99ec0ca5b07831b6037c9a2bfdd3
+    md5: 022c0b5737baf31e8de1ff73de989f83
+work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196401010000-196412312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196401010000-196412312100.nc
+  hashes:
+    binhash: 1114a923945a1feea78069e725c60dca
+    md5: 1d591c6b4762f57f5bf5dba7d250887f
+work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196501010000-196512312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196501010000-196512312100.nc
+  hashes:
+    binhash: 829471eeb340dcd54b0d795206e44e9a
+    md5: a2f5ef596b95c4408b82ab8ab14b5620
+work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196601010000-196612312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196601010000-196612312100.nc
+  hashes:
+    binhash: cfa6bc12d961024a202fd354674783e0
+    md5: 6e6973840cdafddb4317ab5167f99467
+work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196701010000-196712312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196701010000-196712312100.nc
+  hashes:
+    binhash: c282cc26da7a904f6475e86d62bf8e98
+    md5: 96fbe6620f1753a0c24ac65ef013345f
+work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196801010000-196812312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196801010000-196812312100.nc
+  hashes:
+    binhash: 5e1ee22c0f8cbeea12af47f8b01c783d
+    md5: afd9a0fc8da1cb4499c980d8be6d870b
+work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196901010000-196912312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_196901010000-196912312100.nc
+  hashes:
+    binhash: aef84c90f45442a406c35b7a2b85eca3
+    md5: abfff090dbc9e3542ea5cee006ade2b5
+work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197001010000-197012312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197001010000-197012312100.nc
+  hashes:
+    binhash: b8b7141f9d99e294338b2c0947f99f10
+    md5: 4758b01fbc77780335e48e7b896e7130
+work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197101010000-197112312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197101010000-197112312100.nc
+  hashes:
+    binhash: 068d483bb2200c678ccbb305b762e797
+    md5: dda296d7eb6f4a4f95b5cc08b092a153
+work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197201010000-197212312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197201010000-197212312100.nc
+  hashes:
+    binhash: a314c9603b4e8f6e9bb6371004396705
+    md5: 8a742bb2fd797044217d702a46c4279f
+work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197301010000-197312312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197301010000-197312312100.nc
+  hashes:
+    binhash: 5cbf25f7db9ccbee20ab06b603ab3140
+    md5: f7fb220e38ed8641c570bbadf4aa9783
+work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197401010000-197412312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197401010000-197412312100.nc
+  hashes:
+    binhash: e9b712a22a25bb87c27699145f08e82d
+    md5: c6b4ada9493d40da143d9b1534ed25b6
+work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197501010000-197512312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197501010000-197512312100.nc
+  hashes:
+    binhash: 1c783f1c4a21b76c44bc21c850170894
+    md5: be77f004948d51ad51007de88db27ee2
+work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197601010000-197612312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197601010000-197612312100.nc
+  hashes:
+    binhash: 4c2e45abc44ee0883ec79ee9f3f00452
+    md5: 8826b799b071175aaab2884fea807367
+work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197701010000-197712312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197701010000-197712312100.nc
+  hashes:
+    binhash: 6cef3ffa3b62c5034ce68dddcfda502b
+    md5: 27890103b337823427e374c1be32434b
+work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197801010000-197812312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197801010000-197812312100.nc
+  hashes:
+    binhash: 402ef0a3395cd75cb6778d7d2d026b2d
+    md5: 92ec9aeeb648fa0ea810fdc097e9a796
+work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197901010000-197912312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_197901010000-197912312100.nc
+  hashes:
+    binhash: 87f1260c29f48b3b920aa96d89fbce0f
+    md5: bd1f79f77a8ef4fd7c98f7cbb07c6be4
+work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198001010000-198012312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198001010000-198012312100.nc
+  hashes:
+    binhash: cd345ec3d969337aab7073320fadccb2
+    md5: 867983d0747144b851ebf8812690750f
+work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198101010000-198112312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198101010000-198112312100.nc
+  hashes:
+    binhash: d87b04291d9a1b8af915111d4793af04
+    md5: 6bcfdf3d36a6aaa39b6389b339e47a40
+work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198201010000-198212312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198201010000-198212312100.nc
+  hashes:
+    binhash: 1bec0dae9fddae3b5b0b7dee6890f628
+    md5: 65de01429429ad2186fc74b698d9deea
+work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198301010000-198312312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198301010000-198312312100.nc
+  hashes:
+    binhash: 5a405ad04897160e38164f5b0f3a7af0
+    md5: 6ac512888053246844c46d4225c67e7a
+work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198401010000-198412312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198401010000-198412312100.nc
+  hashes:
+    binhash: dfbbf004022b59d5ab1d75705736d9bb
+    md5: d30106d573d06643a5b11f7c34a8d314
+work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198501010000-198512312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198501010000-198512312100.nc
+  hashes:
+    binhash: 99e1635be545fd766113dcafce523483
+    md5: ccbc0f745fdc263c8068f4047856c25c
+work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198601010000-198612312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198601010000-198612312100.nc
+  hashes:
+    binhash: 3199e74fa25f6ed0a98538c8b49ad25c
+    md5: c2f0a9a8bc3babf2a5355c1ec6e70f83
+work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198701010000-198712312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198701010000-198712312100.nc
+  hashes:
+    binhash: 08e7769cea1429a7a3b292ed38f2784d
+    md5: 58316c93020d894779708511cad05e24
+work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198801010000-198812312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198801010000-198812312100.nc
+  hashes:
+    binhash: 44f0c3e3de399b1a76905d9d7a39013b
+    md5: 3b8938e03bda6b9c83f93faa94789233
+work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198901010000-198912312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_198901010000-198912312100.nc
+  hashes:
+    binhash: 7d4627941a31994f59dd8f97deafed77
+    md5: f08ea853ea2157f4b49bda8403b0c1da
+work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199001010000-199012312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199001010000-199012312100.nc
+  hashes:
+    binhash: 84c4685b61e5f13c29cb5a8461a175e2
+    md5: a8fa831264917a94f624c1452ac02672
+work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199101010000-199112312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199101010000-199112312100.nc
+  hashes:
+    binhash: 172abfaef6801cd8b5b386f8f81709f9
+    md5: f5efcefb0359eb3b99f120fc11914422
+work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199201010000-199212312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199201010000-199212312100.nc
+  hashes:
+    binhash: a392aba496e47a46b48b06d432831b43
+    md5: 5d7022d18c399501084c8c8ddc05b34b
+work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199301010000-199312312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199301010000-199312312100.nc
+  hashes:
+    binhash: e5fcd1638fca34d14a8dcac61ed75906
+    md5: ecf42a4ac2949eabbdcd89a7ff75ac9d
+work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199401010000-199412312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199401010000-199412312100.nc
+  hashes:
+    binhash: d955e4d545c9c0b1302f4bc93bf76d5e
+    md5: 3bf1362a075b1e47544b6301730cf3f8
+work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199501010000-199512312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199501010000-199512312100.nc
+  hashes:
+    binhash: 6e3cf099d8075a5efe641eb82d9696dc
+    md5: be9a22862728707081d98cabc1c64b28
+work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199601010000-199612312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199601010000-199612312100.nc
+  hashes:
+    binhash: 2c037f2cec8308d426c97d93da1db4f2
+    md5: d14f22baf7abe6becd1912d4ce3a22f1
+work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199701010000-199712312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199701010000-199712312100.nc
+  hashes:
+    binhash: 4284a80578ac651faa71c4e40018828b
+    md5: b85a0c304db95f308d14b5d22839d418
+work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199801010000-199812312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199801010000-199812312100.nc
+  hashes:
+    binhash: ac8a252a9c4302703e621ae39f8e5775
+    md5: 0775425af0841dbb6d184f10cb6bc35b
+work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199901010000-199912312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_199901010000-199912312100.nc
+  hashes:
+    binhash: df2d23eaf1cf5b51a39bf88be11ec6d5
+    md5: aa1975f526d5c66a673a4ea83489ede3
+work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200001010000-200012312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200001010000-200012312100.nc
+  hashes:
+    binhash: 701f45100eb0cbd5e384e0e78352ab54
+    md5: 8583e75093d98d70bfb67faee1025c5b
+work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200101010000-200112312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200101010000-200112312100.nc
+  hashes:
+    binhash: 8d812ad39c817c52f7c5b68d5f17614a
+    md5: 2831efacdae3a2c51a168006c960db56
+work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200201010000-200212312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200201010000-200212312100.nc
+  hashes:
+    binhash: 8e58044509664475c23647203e512ba1
+    md5: 579c95ce0166213c1d925c3d1e4c2fbf
+work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200301010000-200312312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200301010000-200312312100.nc
+  hashes:
+    binhash: 5bcb5577ee2ef3a3c7c11195eff6d37e
+    md5: 6c92711eda93029252fbcb92f8c40cb9
+work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200401010000-200412312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200401010000-200412312100.nc
+  hashes:
+    binhash: 7ed8cb49d061a5ebc60a2d9a019165e1
+    md5: 965223542edb3093e4221577377ebb57
+work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200501010000-200512312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200501010000-200512312100.nc
+  hashes:
+    binhash: 3621fa8b0d0c6327f1d2f22c404e709a
+    md5: cc59fa25074ccbf3f7b1ef6e77ad0c44
+work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200601010000-200612312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200601010000-200612312100.nc
+  hashes:
+    binhash: a6b505f6e3faa24227e928d88b13060e
+    md5: 804a2bd1108858cc2a3b0ca275e0d723
+work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200701010000-200712312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200701010000-200712312100.nc
+  hashes:
+    binhash: 9423afc07c9fd6b75040cea8ae5bd7be
+    md5: 4e79d6223463d52967032517904bedde
+work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200801010000-200812312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200801010000-200812312100.nc
+  hashes:
+    binhash: e201f392373006e2b303144417e808c9
+    md5: ea3078f76f6a614bf06345bfdff305f5
+work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200901010000-200912312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_200901010000-200912312100.nc
+  hashes:
+    binhash: 0bc93db695351f76d9cf37cc9320da76
+    md5: 22dd1299a4fd15b212ae901f3fdc20e7
+work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201001010000-201012312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201001010000-201012312100.nc
+  hashes:
+    binhash: 40cc4a9958d77a45597ac063dc739af0
+    md5: 8d0a38850775bde0176de6638edf738d
+work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201101010000-201112312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201101010000-201112312100.nc
+  hashes:
+    binhash: bb41349493ae8b4ceb42c940cfe1e7a3
+    md5: c737f4b41d13ac6245a784038db9bb9e
+work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201201010000-201212312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201201010000-201212312100.nc
+  hashes:
+    binhash: 1e6eab1d7e667423e382df7ee9f99b5e
+    md5: b77ca43bb8cc24b15795730bf02ab939
+work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201301010000-201312312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201301010000-201312312100.nc
+  hashes:
+    binhash: 5d0c293e77e71dbc2ae422636b35c45f
+    md5: 777a245fbaaecae5fac3de276774d231
+work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201401010000-201412312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201401010000-201412312100.nc
+  hashes:
+    binhash: a643777ef26bb8ff8c901f74166b9f5c
+    md5: 0b8bd83e7ae70e558031a25f0495edaa
+work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201501010000-201512312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201501010000-201512312100.nc
+  hashes:
+    binhash: 4dcfc5f959df45608eecf33003500d3d
+    md5: 37c37ff8719f5d528d5a987f840f5d8b
+work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201601010000-201612312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201601010000-201612312100.nc
+  hashes:
+    binhash: 1e9dd55526cf1bf2376d74416da33c84
+    md5: 63457e8deb1aaa04558350453c69ac16
+work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201701010000-201712312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201701010000-201712312100.nc
+  hashes:
+    binhash: 32a134c30f8e4bbb4f2698328b452701
+    md5: 53c3d254cb74f3cf4e4e230814b9aa8a
+work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201801010000-201812312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201801010000-201812312100.nc
+  hashes:
+    binhash: 39f8557b105e56a00e704d1dc42a1a44
+    md5: 66c78a5a70d6c0c5cf0bc78bffe26267
+work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201901010000-201912312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_201901010000-201912312100.nc
+  hashes:
+    binhash: 712c8bc07faadd09ec26c4318fcf64a6
+    md5: a45f9f1a5532fff223c825bc83306401
+work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202001010000-202012312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202001010000-202012312100.nc
+  hashes:
+    binhash: 311950671049d1ff74e5c2d02db05114
+    md5: 5736a6a277577479efa4ea9ac9ba016a
+work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202101010000-202112312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202101010000-202112312100.nc
+  hashes:
+    binhash: 0d48489839528a6ce7e42d5bea68a4f7
+    md5: b2eef11453d56dfdcd3483100e913557
+work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202201010000-202212312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202201010000-202212312100.nc
+  hashes:
+    binhash: 8c7d959a2e1a52f1097efaba9fe6b865
+    md5: c137b7ec94c615c52231f66c83653dd5
+work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202301010000-202312312100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202301010000-202312312100.nc
+  hashes:
+    binhash: 0914d05515af3abe6cbd8e9f84842559
+    md5: 3cbbd6c05a4b2765602a9c1367177d4c
+work/atmosphere/INPUT/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202401010000-202402012100.nc:
+  fullpath: /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/atmos/3hrPt/vas/gr/v20240531/vas_input4MIPs_atmosphericState_OMIP_MRI-JRA55-do-1-6-0_gr_202401010000-202402012100.nc
+  hashes:
+    binhash: e437daa09050c288f69a0210ef2fd28f
+    md5: eec2d7bd3e71ed5114136cccb08010d9
 work/ice/RESTART/grid.nc:
   copy: true
   fullpath: /g/data/vk83/configurations/inputs/access-om2/ice/grids/global.01deg/2024.04.17/grid.nc

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -6,9 +6,9 @@ description: |-
   The configuration is based on that described in Kiss et al. (2020),
   https://doi.org/10.5194/gmd-13-401-2020, but with many improvements.
   Initial conditions are WOA13v2 conservative temperature and practical salinity.
-  Run with JRA55-do v1.4.0 interannually-varying forcing with all solid runoff
+  Run with JRA55-do v1.6.0 interannually-varying forcing with all solid runoff
   converted to liquid runoff with no heat transfer.
-  Spin up starts 1 Jan 1958 and runs to 1 Jan 2019.
+  Spin up starts 1 Jan 1958 and runs to 1 Jan 2024.
 notes: |-
   COSIMA request that users of this or other ACCESS-OM2 model code or output data:
   (a) add a project description to COSIMA's list:

--- a/ocean/diag_table_source.yaml
+++ b/ocean/diag_table_source.yaml
@@ -1,0 +1,357 @@
+#######################################################################################################
+# This yaml file is used by make_diag_table.py to create a diag_table file specifying MOM5 diagnostics.
+# Latest version: https://github.com/COSIMA/make_diag_table
+#
+# Define the diagnostics you want in the diag_table section below.
+#
+# The MOM diag_table format is defined here:
+# https://github.com/mom-ocean/MOM5/blob/master/src/shared/diag_manager/diag_table.F90
+#######################################################################################################
+
+
+# Define global default settings which will be applied to all diagnostics,
+# unless overridden in diag_table section below, either in defaults or individual fields.
+# You're unlikely to need to change any of the global_defaults.
+global_defaults:
+# global_section:
+    title: ACCESS-OM2-01  # any string
+    base_date: [ 1900, 1, 1, 0, 0, 0 ]  # reference time used for the time units. six integers: year, month, day, hour, minute, second
+# file section:
+    file_name:  # file name (without trailing ".nc") is constructed from these components,
+    # separated by file_name_separator, as per https://github.com/COSIMA/access-om2/issues/185
+    # All these components (other than field_name) must be names that exist in global_defaults.
+    # If file_name_date or file_name_date_section are used, it must be the last item.
+        - file_name_prefix
+        - file_name_dimension
+        - field_name  # substituted by field name in diag_table section below
+        - output_freq
+        - output_freq_units
+        - reduction_method
+        - file_name_date
+        # - file_name_date_section
+    output_freq: 1  # integer: output sampling frequency in output_freq_units (0: every timestep; -1: only at end of run)
+    output_freq_units: months  # time units for output: years, months, days, hours, minutes, or seconds
+    file_format: 1  # integer, must be 1, specifying NetCDF (the only format currently supported)
+    time_axis_units: days  # time units for the output file time axis: years, months, days, hours, minutes, or seconds
+    time_axis_name: time  # must be "time" (case-insensitive)
+    new_file_freq: 3  # optional integer: frequency (in new_file_freq_units) for closing the existing file, and creating a new file
+    new_file_freq_units: months  # time units for new_file_freq: years, months, days, hours, minutes, or seconds (optional; required if and only if new_file_freq specified)
+    start_time:  # Time to start the file for the first time. The format of this string is the same as base_date (optional; requires new_file_freq, new_file_freq_units)
+    file_duration:  # integer: How long file should receive data after start time (optional; requires new_file_freq, new_file_freq_units, start_time)
+    file_duration_units:  # units for file_duration: years, months, days, hours, minutes, or seconds (optional; required if and only if file_duration specified)
+# field section:
+    module_name: ocean_model
+    field_name:  # set via keys in the fields section of the diag_table section below
+    output_name:  # same as field_name unless overridden
+    # file_name:  # same as file_name in file_section above unless overridden in diag_table section below
+    time_sampling: all  # Currently not used.  Please use the string "all".
+    reduction_method: mean  # mean, snap, rms, pow##, min, max, or diurnal##
+    # reduction_method options:
+    #     mean or average or true: Average from the last time written to the current time. Becomes "average" in diag_table.
+    #     snap or none or false: No reduction.  Write snapshot of current time step value only. Becomes "none" in diag_table.
+    #     rms: Calculate the root mean square from the last time written to the current time.
+    #     pow##: Calculate the mean of the power ## from the last time written to the current time.
+    #     min: Minimum value from last write to current time.
+    #     max: Maximum value from last write to current time.
+    #     diurnal##: ## diurnal averages
+    regional_section: none  # string: bounds of the regional section to capture ("none" indicates a global region). String format: lat_min, lat_max, lon_min, lon_max, vert_min, vert_max. Use vert_min = -1 and vert_max = -1 to get the entire vertical axis.
+    packing: 2
+    # packing is the Fortran number KIND of the data written:
+    #     1: double precision
+    #     2: float (single precision)
+    #     4: packed 16-bit integers
+    #     8: packed 1-byte (not tested)
+# extra things for constructing filename:
+    file_name_dimension: 3d  # descriptor for filename, e.g. 3d, 2d, scalar
+    file_name_prefix: ocean
+    file_name_date: "ym%4yr%2mo"  # run date/time of file opening; format: %, 1 digit (#digits), one of (yr, mo, dy, hr, mi, sc); date/time components will be separated by _ in filename.
+    file_name_separator: "-"  # used to separate filename components; best not to use "_" to avoid confusion with fields and dates
+    file_name_omit_empty: true  # whether to omit empty filename components to avoid duplicate file_name_separator
+    file_name_substitutions:  # string replacements for filename components
+        years: yearly
+        months: monthly
+        days: daily
+        hours: hourly
+        none: snap  # careful! will apply to both reduction_method and regional_section
+        'False': snap
+        average: mean
+        'True': mean
+        None: ""  # for empty items
+    file_name_date_section:  # These are separated by "_". If file_name_date is used, it must be the last item.
+        - output_freq
+        - output_freq_units
+        - reduction_method
+        - file_name_date
+
+
+#######################################################################################################
+# diag_table section - this defines the diagnostics that will appear in diag_table.
+# 
+# Top-level categories in diag_table have arbitrary names (they're just used for
+# comments in the output diag_table). Make as many of these as you like to group
+# similar diagnostics with shared defaults. Note that each of the top-level
+# categories can have only have one instance of each field name, so if you need
+# multiple outputs of the same field (e.g. as both averages and snapshots), you’ll
+# need to make additional categories.
+# 
+# Within each top-level category there's an optional defaults section and a
+# fields section. The defaults section overrides items in global_defaults for
+# all fields in the category. The field section specifies diagnostic field
+# names. To add a new diagnostic, all you need to do is add its name to the
+# field section in the appropriate category. Each field name can be followed by
+# a dictionary overriding the category and global defaults for that field only.
+# 
+# Some of the available diagnostics are listed here:
+# https://raw.githubusercontent.com/COSIMA/access-om2/master/MOM_diags.txt
+# https://github.com/COSIMA/access-om2/wiki/Technical-documentation#MOM5-diagnostics-list
+diag_table:
+    'static 2d grid data':
+        defaults:  # these can be overridden for individual fields below
+            file_name_dimension: 2d  # descriptor for filename, e.g. 3d, 2d, scalar
+            file_name:  # file name (without trailing ".nc") is constructed from these components,
+            # separated by file_name_separator, as per https://github.com/COSIMA/access-om2/issues/185
+            # All these components (other than field_name) must be names that exist in global_defaults.
+                - file_name_prefix
+                - file_name_dimension
+                - field_name  # substituted by field name in fields section below
+            reduction_method: snap  # mean, snap, rms, pow##, min, max, or diurnal##
+            output_freq: -1  # Output frequency in output_freq_units (0: every timestep; -1: only at end of run)
+            new_file_freq:  # optional integer: frequency (in new_file_freq_units) for closing the existing file, and creating a new file
+        fields:
+            area_t:
+            area_u:
+            drag_coeff:
+            dxt:
+            dxu:
+            dyt:
+            dyu:
+            geolat_c:
+            geolat_t:
+            geolon_c:
+            geolon_t:
+            ht:
+            hu:
+            kmt:
+            kmu:
+    'monthly 3d fields':  # should be 3-monthly during spinup
+        defaults:  # these can be overridden for individual fields below
+            file_name_dimension: 3d  # descriptor for filename, e.g. 3d, 2d, scalar
+            output_freq: 1  # integer: output sampling frequency in output_freq_units (0: every timestep; -1: only at end of run)
+            output_freq_units: months  # time units for output: years, months, days, hours, minutes, or seconds
+        fields:
+            age_global:
+            # aiso_bih:
+            buoyfreq2_wt:
+            diff_cbt_t:
+            dzt:  # potentially calculable from other fields - https://github.com/COSIMA/access-om2/issues/203#issuecomment-635752170
+            pot_rho_0:
+            pot_rho_2:
+            pot_temp:
+            salt:
+            temp_xflux_adv:
+            temp_yflux_adv:
+            temp:
+            # tx_trans_gm:
+            # tx_trans_nrho_submeso:
+            # tx_trans_rho_gm:
+            # tx_trans_rho:
+            # tx_trans_submeso:
+            tx_trans:
+            # ty_trans_gm:
+            ty_trans_nrho_submeso:
+            # ty_trans_rho_gm:
+            ty_trans_rho:
+            ty_trans_submeso:
+            ty_trans:
+            u:
+            v:
+            vert_pv:
+            # vorticity_z:
+            wt:
+    'monthly 3d squared fields':  # for calculating EKE etc
+        defaults:  # these can be overridden for individual fields below
+            file_name_dimension: 3d  # descriptor for filename, e.g. 3d, 2d, scalar
+            output_freq: 1  # integer: output sampling frequency in output_freq_units (0: every timestep; -1: only at end of run)
+            output_freq_units: months  # time units for output: years, months, days, hours, minutes, or seconds
+            reduction_method: pow02  # mean, snap, rms, pow##, min, max, or diurnal##
+        fields:
+            u:
+            v:
+    'daily 3d fields':
+        defaults:  # these can be overridden for individual fields below
+            file_name_dimension: 3d  # descriptor for filename, e.g. 3d, 2d, scalar
+            output_freq: 1  # integer: output sampling frequency in output_freq_units (0: every timestep; -1: only at end of run)
+            output_freq_units: days  # time units for output: years, months, days, hours, minutes, or seconds
+            new_file_freq: 1  # optional integer: frequency (in new_file_freq_units) for closing the existing file, and creating a new file
+            new_file_freq_units: months  # time units for new_file_freq: years, months, days, hours, minutes, or seconds (optional; required if and only if new_file_freq specified)
+        fields:
+            # salt:
+            # temp:
+            # u:
+            # v:
+            # wt:
+    'monthly 2d fields':
+        defaults:  # these can be overridden for individual fields below
+            file_name_dimension: 2d  # descriptor for filename, e.g. 3d, 2d, scalar
+            output_freq: 1  # integer: output sampling frequency in output_freq_units (0: every timestep; -1: only at end of run)
+            output_freq_units: months  # time units for output: years, months, days, hours, minutes, or seconds
+        fields:
+            # agm:
+            # aredi:
+            bmf_u:
+            bmf_v:
+            ekman_we:
+            eta_nonbouss:
+            evap_heat:
+            evap:
+            fprec_melt_heat:
+            fprec:
+            frazil_3d_int_z:
+            lprec:
+            lw_heat:
+            melt:
+            mh_flux:
+            mld:
+            net_sfc_heating:
+            pbot_t:
+            pme_net:
+            pme_river:
+            river:
+            runoff:
+            sea_level_sq:
+            sea_level:
+            sens_heat:
+            sfc_hflux_coupler:
+            sfc_hflux_from_runoff:
+            sfc_hflux_pme:
+            sfc_salt_flux_coupler:
+            sfc_salt_flux_ice:
+            sfc_salt_flux_restore:
+            surface_pot_temp:
+            surface_salt:
+            swflx:
+            tau_x:
+            tau_y:
+            temp_int_rhodz:
+            temp_xflux_adv_int_z:
+            # temp_xflux_gm_int_z:
+            # temp_xflux_ndiffuse_int_z:
+            # temp_xflux_submeso_int_z:
+            temp_yflux_adv_int_z:
+            # temp_yflux_gm_int_z:
+            # temp_yflux_ndiffuse_int_z:
+            # temp_yflux_submeso_int_z:
+            tx_trans_int_z:
+            ty_trans_int_z:
+            wfiform:
+            wfimelt:
+    'monthly 2d fields with different reduction methods':
+        defaults:  # these can be overridden for individual fields below
+            file_name_dimension: 2d  # descriptor for filename, e.g. 3d, 2d, scalar
+            output_freq: 1  # integer: output sampling frequency in output_freq_units (0: every timestep; -1: only at end of run)
+            output_freq_units: months  # time units for output: years, months, days, hours, minutes, or seconds
+        fields:
+            mld: {reduction_method: max}  # max avoids spurious small values due to rainfall
+            surface_pot_temp: {reduction_method: min}  # min for comparison with foundation temperature
+    'daily 2d fields':
+        defaults:  # these can be overridden for individual fields below
+            file_name_dimension: 2d  # descriptor for filename, e.g. 3d, 2d, scalar
+            output_freq: 1  # integer: output sampling frequency in output_freq_units (0: every timestep; -1: only at end of run)
+            output_freq_units: days  # time units for output: years, months, days, hours, minutes, or seconds
+        fields:
+            bottom_temp:
+            frazil_3d_int_z:
+            mld:
+            pme_river:
+            sea_level:
+            sfc_hflux_coupler:
+            sfc_hflux_from_runoff:
+            sfc_hflux_pme:
+            surface_pot_temp:
+            surface_salt:
+            usurf:
+            vsurf:
+    'daily 2d maximum fields':
+        defaults:  # these can be overridden for individual fields below
+            file_name_dimension: 2d  # descriptor for filename, e.g. 3d, 2d, scalar
+            output_freq: 1  # integer: output sampling frequency in output_freq_units (0: every timestep; -1: only at end of run)
+            output_freq_units: days  # time units for output: years, months, days, hours, minutes, or seconds
+            reduction_method: max  # mean, snap, rms, pow##, min, max, or diurnal##
+        fields:
+            bottom_temp:
+            sea_level:
+            surface_pot_temp:
+    'daily 2d minimum fields':
+        defaults:  # these can be overridden for individual fields below
+            file_name_dimension: 2d  # descriptor for filename, e.g. 3d, 2d, scalar
+            output_freq: 1  # integer: output sampling frequency in output_freq_units (0: every timestep; -1: only at end of run)
+            output_freq_units: days  # time units for output: years, months, days, hours, minutes, or seconds
+            reduction_method: min  # mean, snap, rms, pow##, min, max, or diurnal##
+        fields:
+            surface_pot_temp:  # min for comparison with foundation temperature
+    'daily scalar snapshots':  # snapshots of global integrals give better parallel performance
+        defaults:  # these can be overridden for individual fields below
+            file_name_dimension: scalar  # descriptor for filename, e.g. 3d, 2d, scalar
+            file_name:  # file name (without trailing ".nc") is constructed from these components,
+            # separated by file_name_separator, as per https://github.com/COSIMA/access-om2/issues/185
+            # All these components (other than field_name) must be names that exist in global_defaults.
+                - file_name_prefix
+                - file_name_dimension
+                - output_freq
+                - output_freq_units
+                - file_name_date
+            output_freq: 1  # integer: output sampling frequency in output_freq_units (0: every timestep; -1: only at end of run)
+            output_freq_units: days  # time units for output: years, months, days, hours, minutes, or seconds
+            reduction_method: snap  # mean, snap, rms, pow##, min, max, or diurnal##
+            packing: 1  # double precision
+        fields:
+            eta_global:
+            ke_tot:
+            pe_tot:
+            rhoave:
+            salt_global_ave:
+            salt_surface_ave:
+            temp_global_ave:
+            temp_surface_ave:
+            total_net_sfc_heating:
+            total_ocean_evap_heat:
+            total_ocean_evap:
+            total_ocean_fprec_melt_heat:
+            total_ocean_fprec:
+            total_ocean_heat:
+            total_ocean_hflux_coupler:
+            total_ocean_hflux_evap:
+            total_ocean_hflux_prec:
+            total_ocean_lprec:
+            total_ocean_lw_heat:
+            total_ocean_melt:
+            total_ocean_mh_flux:
+            total_ocean_pme_river:
+            total_ocean_river_heat:
+            total_ocean_river:
+            total_ocean_runoff_heat:
+            total_ocean_runoff:
+            total_ocean_salt:
+            total_ocean_sens_heat:
+            total_ocean_sfc_salt_flux_coupler:
+            total_ocean_swflx_vis:
+            total_ocean_swflx:
+    'monthly 2d snapshots':
+        defaults:  # these can be overridden for individual fields below
+            file_name_dimension: 2d  # descriptor for filename, e.g. 3d, 2d, scalar
+            output_freq: 1  # integer: output sampling frequency in output_freq_units (0: every timestep; -1: only at end of run)
+            output_freq_units: months  # time units for output: years, months, days, hours, minutes, or seconds
+            reduction_method: snap  # mean, snap, rms, pow##, min, max, or diurnal##
+        fields:
+            # sea_level:
+    'monthly 3d snapshots':
+        defaults:  # these can be overridden for individual fields below
+            file_name_dimension: 3d  # descriptor for filename, e.g. 3d, 2d, scalar
+            output_freq: 1  # integer: output sampling frequency in output_freq_units (0: every timestep; -1: only at end of run)
+            output_freq_units: months  # time units for output: years, months, days, hours, minutes, or seconds
+            reduction_method: snap  # mean, snap, rms, pow##, min, max, or diurnal##
+        fields:
+            # temp:
+            # u:
+            # v:
+            # vorticity_z:


### PR DESCRIPTION
This PR:
- Adds the missing `diag_table_source.yaml` file. Contributes to #283
- Updates to JRA55-do v1.6.0. Contributes to #146
- Adds cost info to README. Contributes to #287