### PR TITLE
Update forcing end date: `dev-1deg_jra55_iaf`

### DIFF
--- a/accessom2.nml
+++ b/accessom2.nml
@@ -12,7 +12,7 @@
 
 &date_manager_nml
     forcing_start_date = '1958-01-01T00:00:00'
-    forcing_end_date = '2019-01-01T00:00:00'
+    forcing_end_date = '2024-01-01T00:00:00'
 
     ! Runtime for a single segment/job/submit, format is years, months, seconds,
     ! two of which must be zero.


### PR DESCRIPTION
This PR updates the `forcing_end_date` for JRA55-do v1.6.0

Contributes to #292