### PR TITLE
Add payu_minimum_version as 1.3.0 in config.yaml

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -103,3 +103,5 @@ userscripts:
 manifest:
   reproduce:
     exe: true
+
+payu_minimum_version: 1.3.0


### PR DESCRIPTION
This PR adds `payu_minimum_version` as 1.3.0 in config.yaml.

Ref [comment](https://github.com/ACCESS-NRI/access-om2-configs/issues/299#issuecomment-4456959637) in #299.