### PR TITLE
Add payu_minimum_version as 1.3.0 in config.yaml.

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -108,3 +108,5 @@ userscripts:
     error: tools/resub.sh
     run: rm -f resubmit.count
     sync: /g/data/vk83/apps/om2-scripts/concatenate_ice/concat_ice_daily.sh
+
+payu_minimum_version: 1.3.0


### PR DESCRIPTION
This PR adds `payu_minimum_version: 1.3.0` in config.yaml.

Ref [comment](https://github.com/ACCESS-NRI/access-om2-configs/issues/299#issuecomment-4456959637) in #299 