### PR TITLE
Use standardised format for MOM diagnostic filenames: `dev-01deg_jra55_ryf`

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -98,6 +98,7 @@ platform:
     nodesize: 48
 # sweep and resubmit on specific errors - see https://github.com/payu-org/payu/issues/241#issuecomment-610739771
 userscripts:
+    archive: /usr/bin/bash /g/data/vk83/apps/om3-scripts/payu_config/archive.sh
     error: tools/resub.sh
     run: rm -f resubmit.count
 manifest:

--- a/ocean/README.md
+++ b/ocean/README.md
@@ -1,0 +1,6 @@
+## Modifying the diag_table
+
+To modify the `diag_table`, make the required modifications to the `diag_table_source.yaml`
+file, then run the script https://github.com/COSIMA/make_diag_table/blob/master/make_diag_table.py
+
+The script is available on Gadi at `/g/data/vk83/apps/make_diag_table/make_diag_table.py`

--- a/ocean/diag_table
+++ b/ocean/diag_table
@@ -10,122 +10,122 @@ ACCESS-OM2-01
 
 # static 2d grid data
 
-"ocean-2d-area_t", -1, "months", 1, "days", "time"
-"ocean_model", "area_t", "area_t", "ocean-2d-area_t", "all", "none", "none", 2
+"access-om2.mom5.2d.area_t.fx", -1, "months", 1, "days", "time"
+"ocean_model", "area_t", "area_t", "access-om2.mom5.2d.area_t.fx", "all", "none", "none", 2
 
-"ocean-2d-area_u", -1, "months", 1, "days", "time"
-"ocean_model", "area_u", "area_u", "ocean-2d-area_u", "all", "none", "none", 2
+"access-om2.mom5.2d.area_u.fx", -1, "months", 1, "days", "time"
+"ocean_model", "area_u", "area_u", "access-om2.mom5.2d.area_u.fx", "all", "none", "none", 2
 
-"ocean-2d-drag_coeff", -1, "months", 1, "days", "time"
-"ocean_model", "drag_coeff", "drag_coeff", "ocean-2d-drag_coeff", "all", "none", "none", 2
+"access-om2.mom5.2d.drag_coeff.fx", -1, "months", 1, "days", "time"
+"ocean_model", "drag_coeff", "drag_coeff", "access-om2.mom5.2d.drag_coeff.fx", "all", "none", "none", 2
 
-"ocean-2d-dxt", -1, "months", 1, "days", "time"
-"ocean_model", "dxt", "dxt", "ocean-2d-dxt", "all", "none", "none", 2
+"access-om2.mom5.2d.dxt.fx", -1, "months", 1, "days", "time"
+"ocean_model", "dxt", "dxt", "access-om2.mom5.2d.dxt.fx", "all", "none", "none", 2
 
-"ocean-2d-dxu", -1, "months", 1, "days", "time"
-"ocean_model", "dxu", "dxu", "ocean-2d-dxu", "all", "none", "none", 2
+"access-om2.mom5.2d.dxu.fx", -1, "months", 1, "days", "time"
+"ocean_model", "dxu", "dxu", "access-om2.mom5.2d.dxu.fx", "all", "none", "none", 2
 
-"ocean-2d-dyt", -1, "months", 1, "days", "time"
-"ocean_model", "dyt", "dyt", "ocean-2d-dyt", "all", "none", "none", 2
+"access-om2.mom5.2d.dyt.fx", -1, "months", 1, "days", "time"
+"ocean_model", "dyt", "dyt", "access-om2.mom5.2d.dyt.fx", "all", "none", "none", 2
 
-"ocean-2d-dyu", -1, "months", 1, "days", "time"
-"ocean_model", "dyu", "dyu", "ocean-2d-dyu", "all", "none", "none", 2
+"access-om2.mom5.2d.dyu.fx", -1, "months", 1, "days", "time"
+"ocean_model", "dyu", "dyu", "access-om2.mom5.2d.dyu.fx", "all", "none", "none", 2
 
-"ocean-2d-geolat_c", -1, "months", 1, "days", "time"
-"ocean_model", "geolat_c", "geolat_c", "ocean-2d-geolat_c", "all", "none", "none", 2
+"access-om2.mom5.2d.geolat_c.fx", -1, "months", 1, "days", "time"
+"ocean_model", "geolat_c", "geolat_c", "access-om2.mom5.2d.geolat_c.fx", "all", "none", "none", 2
 
-"ocean-2d-geolat_t", -1, "months", 1, "days", "time"
-"ocean_model", "geolat_t", "geolat_t", "ocean-2d-geolat_t", "all", "none", "none", 2
+"access-om2.mom5.2d.geolat_t.fx", -1, "months", 1, "days", "time"
+"ocean_model", "geolat_t", "geolat_t", "access-om2.mom5.2d.geolat_t.fx", "all", "none", "none", 2
 
-"ocean-2d-geolon_c", -1, "months", 1, "days", "time"
-"ocean_model", "geolon_c", "geolon_c", "ocean-2d-geolon_c", "all", "none", "none", 2
+"access-om2.mom5.2d.geolon_c.fx", -1, "months", 1, "days", "time"
+"ocean_model", "geolon_c", "geolon_c", "access-om2.mom5.2d.geolon_c.fx", "all", "none", "none", 2
 
-"ocean-2d-geolon_t", -1, "months", 1, "days", "time"
-"ocean_model", "geolon_t", "geolon_t", "ocean-2d-geolon_t", "all", "none", "none", 2
+"access-om2.mom5.2d.geolon_t.fx", -1, "months", 1, "days", "time"
+"ocean_model", "geolon_t", "geolon_t", "access-om2.mom5.2d.geolon_t.fx", "all", "none", "none", 2
 
-"ocean-2d-ht", -1, "months", 1, "days", "time"
-"ocean_model", "ht", "ht", "ocean-2d-ht", "all", "none", "none", 2
+"access-om2.mom5.2d.ht.fx", -1, "months", 1, "days", "time"
+"ocean_model", "ht", "ht", "access-om2.mom5.2d.ht.fx", "all", "none", "none", 2
 
-"ocean-2d-hu", -1, "months", 1, "days", "time"
-"ocean_model", "hu", "hu", "ocean-2d-hu", "all", "none", "none", 2
+"access-om2.mom5.2d.hu.fx", -1, "months", 1, "days", "time"
+"ocean_model", "hu", "hu", "access-om2.mom5.2d.hu.fx", "all", "none", "none", 2
 
-"ocean-2d-kmt", -1, "months", 1, "days", "time"
-"ocean_model", "kmt", "kmt", "ocean-2d-kmt", "all", "none", "none", 2
+"access-om2.mom5.2d.kmt.fx", -1, "months", 1, "days", "time"
+"ocean_model", "kmt", "kmt", "access-om2.mom5.2d.kmt.fx", "all", "none", "none", 2
 
-"ocean-2d-kmu", -1, "months", 1, "days", "time"
-"ocean_model", "kmu", "kmu", "ocean-2d-kmu", "all", "none", "none", 2
+"access-om2.mom5.2d.kmu.fx", -1, "months", 1, "days", "time"
+"ocean_model", "kmu", "kmu", "access-om2.mom5.2d.kmu.fx", "all", "none", "none", 2
 
 
 # monthly 3d fields
 
-"ocean-3d-age_global-1-monthly-mean-ym%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
-"ocean_model", "age_global", "age_global", "ocean-3d-age_global-1-monthly-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.3d.age_global.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
+"ocean_model", "age_global", "age_global", "access-om2.mom5.3d.age_global.1mon.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-3d-buoyfreq2_wt-1-monthly-mean-ym%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
-"ocean_model", "buoyfreq2_wt", "buoyfreq2_wt", "ocean-3d-buoyfreq2_wt-1-monthly-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.3d.buoyfreq2_wt.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
+"ocean_model", "buoyfreq2_wt", "buoyfreq2_wt", "access-om2.mom5.3d.buoyfreq2_wt.1mon.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-3d-diff_cbt_t-1-monthly-mean-ym%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
-"ocean_model", "diff_cbt_t", "diff_cbt_t", "ocean-3d-diff_cbt_t-1-monthly-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.3d.diff_cbt_t.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
+"ocean_model", "diff_cbt_t", "diff_cbt_t", "access-om2.mom5.3d.diff_cbt_t.1mon.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-3d-dzt-1-monthly-mean-ym%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
-"ocean_model", "dzt", "dzt", "ocean-3d-dzt-1-monthly-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.3d.dzt.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
+"ocean_model", "dzt", "dzt", "access-om2.mom5.3d.dzt.1mon.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-3d-pot_rho_0-1-monthly-mean-ym%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
-"ocean_model", "pot_rho_0", "pot_rho_0", "ocean-3d-pot_rho_0-1-monthly-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.3d.pot_rho_0.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
+"ocean_model", "pot_rho_0", "pot_rho_0", "access-om2.mom5.3d.pot_rho_0.1mon.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-3d-pot_rho_2-1-monthly-mean-ym%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
-"ocean_model", "pot_rho_2", "pot_rho_2", "ocean-3d-pot_rho_2-1-monthly-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.3d.pot_rho_2.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
+"ocean_model", "pot_rho_2", "pot_rho_2", "access-om2.mom5.3d.pot_rho_2.1mon.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-3d-pot_temp-1-monthly-mean-ym%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
-"ocean_model", "pot_temp", "pot_temp", "ocean-3d-pot_temp-1-monthly-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.3d.pot_temp.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
+"ocean_model", "pot_temp", "pot_temp", "access-om2.mom5.3d.pot_temp.1mon.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-3d-salt-1-monthly-mean-ym%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
-"ocean_model", "salt", "salt", "ocean-3d-salt-1-monthly-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.3d.salt.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
+"ocean_model", "salt", "salt", "access-om2.mom5.3d.salt.1mon.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-3d-temp_xflux_adv-1-monthly-mean-ym%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
-"ocean_model", "temp_xflux_adv", "temp_xflux_adv", "ocean-3d-temp_xflux_adv-1-monthly-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.3d.temp_xflux_adv.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
+"ocean_model", "temp_xflux_adv", "temp_xflux_adv", "access-om2.mom5.3d.temp_xflux_adv.1mon.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-3d-temp_yflux_adv-1-monthly-mean-ym%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
-"ocean_model", "temp_yflux_adv", "temp_yflux_adv", "ocean-3d-temp_yflux_adv-1-monthly-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.3d.temp_yflux_adv.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
+"ocean_model", "temp_yflux_adv", "temp_yflux_adv", "access-om2.mom5.3d.temp_yflux_adv.1mon.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-3d-temp-1-monthly-mean-ym%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
-"ocean_model", "temp", "temp", "ocean-3d-temp-1-monthly-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.3d.temp.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
+"ocean_model", "temp", "temp", "access-om2.mom5.3d.temp.1mon.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-3d-tx_trans-1-monthly-mean-ym%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
-"ocean_model", "tx_trans", "tx_trans", "ocean-3d-tx_trans-1-monthly-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.3d.tx_trans.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
+"ocean_model", "tx_trans", "tx_trans", "access-om2.mom5.3d.tx_trans.1mon.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-3d-ty_trans_nrho_submeso-1-monthly-mean-ym%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
-"ocean_model", "ty_trans_nrho_submeso", "ty_trans_nrho_submeso", "ocean-3d-ty_trans_nrho_submeso-1-monthly-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.3d.ty_trans_nrho_submeso.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
+"ocean_model", "ty_trans_nrho_submeso", "ty_trans_nrho_submeso", "access-om2.mom5.3d.ty_trans_nrho_submeso.1mon.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-3d-ty_trans_rho-1-monthly-mean-ym%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
-"ocean_model", "ty_trans_rho", "ty_trans_rho", "ocean-3d-ty_trans_rho-1-monthly-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.3d.ty_trans_rho.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
+"ocean_model", "ty_trans_rho", "ty_trans_rho", "access-om2.mom5.3d.ty_trans_rho.1mon.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-3d-ty_trans_submeso-1-monthly-mean-ym%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
-"ocean_model", "ty_trans_submeso", "ty_trans_submeso", "ocean-3d-ty_trans_submeso-1-monthly-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.3d.ty_trans_submeso.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
+"ocean_model", "ty_trans_submeso", "ty_trans_submeso", "access-om2.mom5.3d.ty_trans_submeso.1mon.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-3d-ty_trans-1-monthly-mean-ym%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
-"ocean_model", "ty_trans", "ty_trans", "ocean-3d-ty_trans-1-monthly-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.3d.ty_trans.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
+"ocean_model", "ty_trans", "ty_trans", "access-om2.mom5.3d.ty_trans.1mon.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-3d-u-1-monthly-mean-ym%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
-"ocean_model", "u", "u", "ocean-3d-u-1-monthly-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.3d.u.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
+"ocean_model", "u", "u", "access-om2.mom5.3d.u.1mon.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-3d-v-1-monthly-mean-ym%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
-"ocean_model", "v", "v", "ocean-3d-v-1-monthly-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.3d.v.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
+"ocean_model", "v", "v", "access-om2.mom5.3d.v.1mon.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-3d-vert_pv-1-monthly-mean-ym%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
-"ocean_model", "vert_pv", "vert_pv", "ocean-3d-vert_pv-1-monthly-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.3d.vert_pv.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
+"ocean_model", "vert_pv", "vert_pv", "access-om2.mom5.3d.vert_pv.1mon.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-3d-wt-1-monthly-mean-ym%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
-"ocean_model", "wt", "wt", "ocean-3d-wt-1-monthly-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.3d.wt.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
+"ocean_model", "wt", "wt", "access-om2.mom5.3d.wt.1mon.mean.%4yr%2mo", "all", "average", "none", 2
 
 
 # monthly 3d squared fields
 
-"ocean-3d-u-1-monthly-pow02-ym%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
-"ocean_model", "u", "u", "ocean-3d-u-1-monthly-pow02-ym%4yr%2mo", "all", "pow02", "none", 2
+"access-om2.mom5.3d.u.1mon.pow02.%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
+"ocean_model", "u", "u", "access-om2.mom5.3d.u.1mon.pow02.%4yr%2mo", "all", "pow02", "none", 2
 
-"ocean-3d-v-1-monthly-pow02-ym%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
-"ocean_model", "v", "v", "ocean-3d-v-1-monthly-pow02-ym%4yr%2mo", "all", "pow02", "none", 2
+"access-om2.mom5.3d.v.1mon.pow02.%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
+"ocean_model", "v", "v", "access-om2.mom5.3d.v.1mon.pow02.%4yr%2mo", "all", "pow02", "none", 2
 
 
 # daily 3d fields
@@ -133,230 +133,230 @@ ACCESS-OM2-01
 
 # monthly 2d fields
 
-"ocean-2d-bmf_u-1-monthly-mean-ym%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
-"ocean_model", "bmf_u", "bmf_u", "ocean-2d-bmf_u-1-monthly-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.2d.bmf_u.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
+"ocean_model", "bmf_u", "bmf_u", "access-om2.mom5.2d.bmf_u.1mon.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-2d-bmf_v-1-monthly-mean-ym%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
-"ocean_model", "bmf_v", "bmf_v", "ocean-2d-bmf_v-1-monthly-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.2d.bmf_v.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
+"ocean_model", "bmf_v", "bmf_v", "access-om2.mom5.2d.bmf_v.1mon.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-2d-ekman_we-1-monthly-mean-ym%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
-"ocean_model", "ekman_we", "ekman_we", "ocean-2d-ekman_we-1-monthly-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.2d.ekman_we.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
+"ocean_model", "ekman_we", "ekman_we", "access-om2.mom5.2d.ekman_we.1mon.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-2d-eta_nonbouss-1-monthly-mean-ym%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
-"ocean_model", "eta_nonbouss", "eta_nonbouss", "ocean-2d-eta_nonbouss-1-monthly-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.2d.eta_nonbouss.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
+"ocean_model", "eta_nonbouss", "eta_nonbouss", "access-om2.mom5.2d.eta_nonbouss.1mon.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-2d-evap_heat-1-monthly-mean-ym%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
-"ocean_model", "evap_heat", "evap_heat", "ocean-2d-evap_heat-1-monthly-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.2d.evap_heat.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
+"ocean_model", "evap_heat", "evap_heat", "access-om2.mom5.2d.evap_heat.1mon.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-2d-evap-1-monthly-mean-ym%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
-"ocean_model", "evap", "evap", "ocean-2d-evap-1-monthly-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.2d.evap.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
+"ocean_model", "evap", "evap", "access-om2.mom5.2d.evap.1mon.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-2d-fprec_melt_heat-1-monthly-mean-ym%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
-"ocean_model", "fprec_melt_heat", "fprec_melt_heat", "ocean-2d-fprec_melt_heat-1-monthly-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.2d.fprec_melt_heat.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
+"ocean_model", "fprec_melt_heat", "fprec_melt_heat", "access-om2.mom5.2d.fprec_melt_heat.1mon.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-2d-fprec-1-monthly-mean-ym%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
-"ocean_model", "fprec", "fprec", "ocean-2d-fprec-1-monthly-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.2d.fprec.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
+"ocean_model", "fprec", "fprec", "access-om2.mom5.2d.fprec.1mon.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-2d-frazil_3d_int_z-1-monthly-mean-ym%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
-"ocean_model", "frazil_3d_int_z", "frazil_3d_int_z", "ocean-2d-frazil_3d_int_z-1-monthly-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.2d.frazil_3d_int_z.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
+"ocean_model", "frazil_3d_int_z", "frazil_3d_int_z", "access-om2.mom5.2d.frazil_3d_int_z.1mon.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-2d-lprec-1-monthly-mean-ym%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
-"ocean_model", "lprec", "lprec", "ocean-2d-lprec-1-monthly-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.2d.lprec.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
+"ocean_model", "lprec", "lprec", "access-om2.mom5.2d.lprec.1mon.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-2d-lw_heat-1-monthly-mean-ym%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
-"ocean_model", "lw_heat", "lw_heat", "ocean-2d-lw_heat-1-monthly-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.2d.lw_heat.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
+"ocean_model", "lw_heat", "lw_heat", "access-om2.mom5.2d.lw_heat.1mon.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-2d-melt-1-monthly-mean-ym%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
-"ocean_model", "melt", "melt", "ocean-2d-melt-1-monthly-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.2d.melt.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
+"ocean_model", "melt", "melt", "access-om2.mom5.2d.melt.1mon.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-2d-mh_flux-1-monthly-mean-ym%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
-"ocean_model", "mh_flux", "mh_flux", "ocean-2d-mh_flux-1-monthly-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.2d.mh_flux.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
+"ocean_model", "mh_flux", "mh_flux", "access-om2.mom5.2d.mh_flux.1mon.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-2d-mld-1-monthly-mean-ym%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
-"ocean_model", "mld", "mld", "ocean-2d-mld-1-monthly-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.2d.mld.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
+"ocean_model", "mld", "mld", "access-om2.mom5.2d.mld.1mon.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-2d-net_sfc_heating-1-monthly-mean-ym%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
-"ocean_model", "net_sfc_heating", "net_sfc_heating", "ocean-2d-net_sfc_heating-1-monthly-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.2d.net_sfc_heating.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
+"ocean_model", "net_sfc_heating", "net_sfc_heating", "access-om2.mom5.2d.net_sfc_heating.1mon.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-2d-pbot_t-1-monthly-mean-ym%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
-"ocean_model", "pbot_t", "pbot_t", "ocean-2d-pbot_t-1-monthly-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.2d.pbot_t.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
+"ocean_model", "pbot_t", "pbot_t", "access-om2.mom5.2d.pbot_t.1mon.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-2d-pme_net-1-monthly-mean-ym%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
-"ocean_model", "pme_net", "pme_net", "ocean-2d-pme_net-1-monthly-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.2d.pme_net.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
+"ocean_model", "pme_net", "pme_net", "access-om2.mom5.2d.pme_net.1mon.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-2d-pme_river-1-monthly-mean-ym%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
-"ocean_model", "pme_river", "pme_river", "ocean-2d-pme_river-1-monthly-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.2d.pme_river.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
+"ocean_model", "pme_river", "pme_river", "access-om2.mom5.2d.pme_river.1mon.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-2d-river-1-monthly-mean-ym%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
-"ocean_model", "river", "river", "ocean-2d-river-1-monthly-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.2d.river.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
+"ocean_model", "river", "river", "access-om2.mom5.2d.river.1mon.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-2d-runoff-1-monthly-mean-ym%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
-"ocean_model", "runoff", "runoff", "ocean-2d-runoff-1-monthly-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.2d.runoff.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
+"ocean_model", "runoff", "runoff", "access-om2.mom5.2d.runoff.1mon.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-2d-sea_level_sq-1-monthly-mean-ym%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
-"ocean_model", "sea_level_sq", "sea_level_sq", "ocean-2d-sea_level_sq-1-monthly-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.2d.sea_level_sq.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
+"ocean_model", "sea_level_sq", "sea_level_sq", "access-om2.mom5.2d.sea_level_sq.1mon.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-2d-sea_level-1-monthly-mean-ym%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
-"ocean_model", "sea_level", "sea_level", "ocean-2d-sea_level-1-monthly-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.2d.sea_level.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
+"ocean_model", "sea_level", "sea_level", "access-om2.mom5.2d.sea_level.1mon.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-2d-sens_heat-1-monthly-mean-ym%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
-"ocean_model", "sens_heat", "sens_heat", "ocean-2d-sens_heat-1-monthly-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.2d.sens_heat.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
+"ocean_model", "sens_heat", "sens_heat", "access-om2.mom5.2d.sens_heat.1mon.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-2d-sfc_hflux_coupler-1-monthly-mean-ym%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
-"ocean_model", "sfc_hflux_coupler", "sfc_hflux_coupler", "ocean-2d-sfc_hflux_coupler-1-monthly-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.2d.sfc_hflux_coupler.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
+"ocean_model", "sfc_hflux_coupler", "sfc_hflux_coupler", "access-om2.mom5.2d.sfc_hflux_coupler.1mon.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-2d-sfc_hflux_from_runoff-1-monthly-mean-ym%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
-"ocean_model", "sfc_hflux_from_runoff", "sfc_hflux_from_runoff", "ocean-2d-sfc_hflux_from_runoff-1-monthly-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.2d.sfc_hflux_from_runoff.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
+"ocean_model", "sfc_hflux_from_runoff", "sfc_hflux_from_runoff", "access-om2.mom5.2d.sfc_hflux_from_runoff.1mon.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-2d-sfc_hflux_pme-1-monthly-mean-ym%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
-"ocean_model", "sfc_hflux_pme", "sfc_hflux_pme", "ocean-2d-sfc_hflux_pme-1-monthly-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.2d.sfc_hflux_pme.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
+"ocean_model", "sfc_hflux_pme", "sfc_hflux_pme", "access-om2.mom5.2d.sfc_hflux_pme.1mon.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-2d-sfc_salt_flux_coupler-1-monthly-mean-ym%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
-"ocean_model", "sfc_salt_flux_coupler", "sfc_salt_flux_coupler", "ocean-2d-sfc_salt_flux_coupler-1-monthly-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.2d.sfc_salt_flux_coupler.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
+"ocean_model", "sfc_salt_flux_coupler", "sfc_salt_flux_coupler", "access-om2.mom5.2d.sfc_salt_flux_coupler.1mon.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-2d-sfc_salt_flux_ice-1-monthly-mean-ym%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
-"ocean_model", "sfc_salt_flux_ice", "sfc_salt_flux_ice", "ocean-2d-sfc_salt_flux_ice-1-monthly-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.2d.sfc_salt_flux_ice.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
+"ocean_model", "sfc_salt_flux_ice", "sfc_salt_flux_ice", "access-om2.mom5.2d.sfc_salt_flux_ice.1mon.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-2d-sfc_salt_flux_restore-1-monthly-mean-ym%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
-"ocean_model", "sfc_salt_flux_restore", "sfc_salt_flux_restore", "ocean-2d-sfc_salt_flux_restore-1-monthly-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.2d.sfc_salt_flux_restore.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
+"ocean_model", "sfc_salt_flux_restore", "sfc_salt_flux_restore", "access-om2.mom5.2d.sfc_salt_flux_restore.1mon.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-2d-surface_pot_temp-1-monthly-mean-ym%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
-"ocean_model", "surface_pot_temp", "surface_pot_temp", "ocean-2d-surface_pot_temp-1-monthly-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.2d.surface_pot_temp.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
+"ocean_model", "surface_pot_temp", "surface_pot_temp", "access-om2.mom5.2d.surface_pot_temp.1mon.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-2d-surface_salt-1-monthly-mean-ym%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
-"ocean_model", "surface_salt", "surface_salt", "ocean-2d-surface_salt-1-monthly-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.2d.surface_salt.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
+"ocean_model", "surface_salt", "surface_salt", "access-om2.mom5.2d.surface_salt.1mon.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-2d-swflx-1-monthly-mean-ym%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
-"ocean_model", "swflx", "swflx", "ocean-2d-swflx-1-monthly-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.2d.swflx.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
+"ocean_model", "swflx", "swflx", "access-om2.mom5.2d.swflx.1mon.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-2d-tau_x-1-monthly-mean-ym%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
-"ocean_model", "tau_x", "tau_x", "ocean-2d-tau_x-1-monthly-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.2d.tau_x.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
+"ocean_model", "tau_x", "tau_x", "access-om2.mom5.2d.tau_x.1mon.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-2d-tau_y-1-monthly-mean-ym%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
-"ocean_model", "tau_y", "tau_y", "ocean-2d-tau_y-1-monthly-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.2d.tau_y.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
+"ocean_model", "tau_y", "tau_y", "access-om2.mom5.2d.tau_y.1mon.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-2d-temp_int_rhodz-1-monthly-mean-ym%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
-"ocean_model", "temp_int_rhodz", "temp_int_rhodz", "ocean-2d-temp_int_rhodz-1-monthly-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.2d.temp_int_rhodz.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
+"ocean_model", "temp_int_rhodz", "temp_int_rhodz", "access-om2.mom5.2d.temp_int_rhodz.1mon.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-2d-temp_xflux_adv_int_z-1-monthly-mean-ym%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
-"ocean_model", "temp_xflux_adv_int_z", "temp_xflux_adv_int_z", "ocean-2d-temp_xflux_adv_int_z-1-monthly-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.2d.temp_xflux_adv_int_z.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
+"ocean_model", "temp_xflux_adv_int_z", "temp_xflux_adv_int_z", "access-om2.mom5.2d.temp_xflux_adv_int_z.1mon.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-2d-temp_yflux_adv_int_z-1-monthly-mean-ym%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
-"ocean_model", "temp_yflux_adv_int_z", "temp_yflux_adv_int_z", "ocean-2d-temp_yflux_adv_int_z-1-monthly-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.2d.temp_yflux_adv_int_z.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
+"ocean_model", "temp_yflux_adv_int_z", "temp_yflux_adv_int_z", "access-om2.mom5.2d.temp_yflux_adv_int_z.1mon.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-2d-tx_trans_int_z-1-monthly-mean-ym%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
-"ocean_model", "tx_trans_int_z", "tx_trans_int_z", "ocean-2d-tx_trans_int_z-1-monthly-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.2d.tx_trans_int_z.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
+"ocean_model", "tx_trans_int_z", "tx_trans_int_z", "access-om2.mom5.2d.tx_trans_int_z.1mon.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-2d-ty_trans_int_z-1-monthly-mean-ym%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
-"ocean_model", "ty_trans_int_z", "ty_trans_int_z", "ocean-2d-ty_trans_int_z-1-monthly-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.2d.ty_trans_int_z.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
+"ocean_model", "ty_trans_int_z", "ty_trans_int_z", "access-om2.mom5.2d.ty_trans_int_z.1mon.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-2d-wfiform-1-monthly-mean-ym%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
-"ocean_model", "wfiform", "wfiform", "ocean-2d-wfiform-1-monthly-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.2d.wfiform.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
+"ocean_model", "wfiform", "wfiform", "access-om2.mom5.2d.wfiform.1mon.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-2d-wfimelt-1-monthly-mean-ym%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
-"ocean_model", "wfimelt", "wfimelt", "ocean-2d-wfimelt-1-monthly-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.2d.wfimelt.1mon.mean.%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
+"ocean_model", "wfimelt", "wfimelt", "access-om2.mom5.2d.wfimelt.1mon.mean.%4yr%2mo", "all", "average", "none", 2
 
 
 # monthly 2d fields with different reduction methods
 
-"ocean-2d-mld-1-monthly-max-ym%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
-"ocean_model", "mld", "mld", "ocean-2d-mld-1-monthly-max-ym%4yr%2mo", "all", "max", "none", 2
+"access-om2.mom5.2d.mld.1mon.max.%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
+"ocean_model", "mld", "mld", "access-om2.mom5.2d.mld.1mon.max.%4yr%2mo", "all", "max", "none", 2
 
-"ocean-2d-surface_pot_temp-1-monthly-min-ym%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
-"ocean_model", "surface_pot_temp", "surface_pot_temp", "ocean-2d-surface_pot_temp-1-monthly-min-ym%4yr%2mo", "all", "min", "none", 2
+"access-om2.mom5.2d.surface_pot_temp.1mon.min.%4yr%2mo", 1, "months", 1, "days", "time", 3, "months"
+"ocean_model", "surface_pot_temp", "surface_pot_temp", "access-om2.mom5.2d.surface_pot_temp.1mon.min.%4yr%2mo", "all", "min", "none", 2
 
 
 # daily 2d fields
 
-"ocean-2d-bottom_temp-1-daily-mean-ym%4yr%2mo", 1, "days", 1, "days", "time", 3, "months"
-"ocean_model", "bottom_temp", "bottom_temp", "ocean-2d-bottom_temp-1-daily-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.2d.bottom_temp.1day.mean.%4yr%2mo", 1, "days", 1, "days", "time", 3, "months"
+"ocean_model", "bottom_temp", "bottom_temp", "access-om2.mom5.2d.bottom_temp.1day.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-2d-frazil_3d_int_z-1-daily-mean-ym%4yr%2mo", 1, "days", 1, "days", "time", 3, "months"
-"ocean_model", "frazil_3d_int_z", "frazil_3d_int_z", "ocean-2d-frazil_3d_int_z-1-daily-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.2d.frazil_3d_int_z.1day.mean.%4yr%2mo", 1, "days", 1, "days", "time", 3, "months"
+"ocean_model", "frazil_3d_int_z", "frazil_3d_int_z", "access-om2.mom5.2d.frazil_3d_int_z.1day.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-2d-mld-1-daily-mean-ym%4yr%2mo", 1, "days", 1, "days", "time", 3, "months"
-"ocean_model", "mld", "mld", "ocean-2d-mld-1-daily-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.2d.mld.1day.mean.%4yr%2mo", 1, "days", 1, "days", "time", 3, "months"
+"ocean_model", "mld", "mld", "access-om2.mom5.2d.mld.1day.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-2d-pme_river-1-daily-mean-ym%4yr%2mo", 1, "days", 1, "days", "time", 3, "months"
-"ocean_model", "pme_river", "pme_river", "ocean-2d-pme_river-1-daily-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.2d.pme_river.1day.mean.%4yr%2mo", 1, "days", 1, "days", "time", 3, "months"
+"ocean_model", "pme_river", "pme_river", "access-om2.mom5.2d.pme_river.1day.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-2d-sea_level-1-daily-mean-ym%4yr%2mo", 1, "days", 1, "days", "time", 3, "months"
-"ocean_model", "sea_level", "sea_level", "ocean-2d-sea_level-1-daily-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.2d.sea_level.1day.mean.%4yr%2mo", 1, "days", 1, "days", "time", 3, "months"
+"ocean_model", "sea_level", "sea_level", "access-om2.mom5.2d.sea_level.1day.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-2d-sfc_hflux_coupler-1-daily-mean-ym%4yr%2mo", 1, "days", 1, "days", "time", 3, "months"
-"ocean_model", "sfc_hflux_coupler", "sfc_hflux_coupler", "ocean-2d-sfc_hflux_coupler-1-daily-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.2d.sfc_hflux_coupler.1day.mean.%4yr%2mo", 1, "days", 1, "days", "time", 3, "months"
+"ocean_model", "sfc_hflux_coupler", "sfc_hflux_coupler", "access-om2.mom5.2d.sfc_hflux_coupler.1day.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-2d-sfc_hflux_from_runoff-1-daily-mean-ym%4yr%2mo", 1, "days", 1, "days", "time", 3, "months"
-"ocean_model", "sfc_hflux_from_runoff", "sfc_hflux_from_runoff", "ocean-2d-sfc_hflux_from_runoff-1-daily-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.2d.sfc_hflux_from_runoff.1day.mean.%4yr%2mo", 1, "days", 1, "days", "time", 3, "months"
+"ocean_model", "sfc_hflux_from_runoff", "sfc_hflux_from_runoff", "access-om2.mom5.2d.sfc_hflux_from_runoff.1day.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-2d-sfc_hflux_pme-1-daily-mean-ym%4yr%2mo", 1, "days", 1, "days", "time", 3, "months"
-"ocean_model", "sfc_hflux_pme", "sfc_hflux_pme", "ocean-2d-sfc_hflux_pme-1-daily-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.2d.sfc_hflux_pme.1day.mean.%4yr%2mo", 1, "days", 1, "days", "time", 3, "months"
+"ocean_model", "sfc_hflux_pme", "sfc_hflux_pme", "access-om2.mom5.2d.sfc_hflux_pme.1day.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-2d-surface_pot_temp-1-daily-mean-ym%4yr%2mo", 1, "days", 1, "days", "time", 3, "months"
-"ocean_model", "surface_pot_temp", "surface_pot_temp", "ocean-2d-surface_pot_temp-1-daily-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.2d.surface_pot_temp.1day.mean.%4yr%2mo", 1, "days", 1, "days", "time", 3, "months"
+"ocean_model", "surface_pot_temp", "surface_pot_temp", "access-om2.mom5.2d.surface_pot_temp.1day.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-2d-surface_salt-1-daily-mean-ym%4yr%2mo", 1, "days", 1, "days", "time", 3, "months"
-"ocean_model", "surface_salt", "surface_salt", "ocean-2d-surface_salt-1-daily-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.2d.surface_salt.1day.mean.%4yr%2mo", 1, "days", 1, "days", "time", 3, "months"
+"ocean_model", "surface_salt", "surface_salt", "access-om2.mom5.2d.surface_salt.1day.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-2d-usurf-1-daily-mean-ym%4yr%2mo", 1, "days", 1, "days", "time", 3, "months"
-"ocean_model", "usurf", "usurf", "ocean-2d-usurf-1-daily-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.2d.usurf.1day.mean.%4yr%2mo", 1, "days", 1, "days", "time", 3, "months"
+"ocean_model", "usurf", "usurf", "access-om2.mom5.2d.usurf.1day.mean.%4yr%2mo", "all", "average", "none", 2
 
-"ocean-2d-vsurf-1-daily-mean-ym%4yr%2mo", 1, "days", 1, "days", "time", 3, "months"
-"ocean_model", "vsurf", "vsurf", "ocean-2d-vsurf-1-daily-mean-ym%4yr%2mo", "all", "average", "none", 2
+"access-om2.mom5.2d.vsurf.1day.mean.%4yr%2mo", 1, "days", 1, "days", "time", 3, "months"
+"ocean_model", "vsurf", "vsurf", "access-om2.mom5.2d.vsurf.1day.mean.%4yr%2mo", "all", "average", "none", 2
 
 
 # daily 2d maximum fields
 
-"ocean-2d-bottom_temp-1-daily-max-ym%4yr%2mo", 1, "days", 1, "days", "time", 3, "months"
-"ocean_model", "bottom_temp", "bottom_temp", "ocean-2d-bottom_temp-1-daily-max-ym%4yr%2mo", "all", "max", "none", 2
+"access-om2.mom5.2d.bottom_temp.1day.max.%4yr%2mo", 1, "days", 1, "days", "time", 3, "months"
+"ocean_model", "bottom_temp", "bottom_temp", "access-om2.mom5.2d.bottom_temp.1day.max.%4yr%2mo", "all", "max", "none", 2
 
-"ocean-2d-sea_level-1-daily-max-ym%4yr%2mo", 1, "days", 1, "days", "time", 3, "months"
-"ocean_model", "sea_level", "sea_level", "ocean-2d-sea_level-1-daily-max-ym%4yr%2mo", "all", "max", "none", 2
+"access-om2.mom5.2d.sea_level.1day.max.%4yr%2mo", 1, "days", 1, "days", "time", 3, "months"
+"ocean_model", "sea_level", "sea_level", "access-om2.mom5.2d.sea_level.1day.max.%4yr%2mo", "all", "max", "none", 2
 
-"ocean-2d-surface_pot_temp-1-daily-max-ym%4yr%2mo", 1, "days", 1, "days", "time", 3, "months"
-"ocean_model", "surface_pot_temp", "surface_pot_temp", "ocean-2d-surface_pot_temp-1-daily-max-ym%4yr%2mo", "all", "max", "none", 2
+"access-om2.mom5.2d.surface_pot_temp.1day.max.%4yr%2mo", 1, "days", 1, "days", "time", 3, "months"
+"ocean_model", "surface_pot_temp", "surface_pot_temp", "access-om2.mom5.2d.surface_pot_temp.1day.max.%4yr%2mo", "all", "max", "none", 2
 
 
 # daily 2d minimum fields
 
-"ocean-2d-surface_pot_temp-1-daily-min-ym%4yr%2mo", 1, "days", 1, "days", "time", 3, "months"
-"ocean_model", "surface_pot_temp", "surface_pot_temp", "ocean-2d-surface_pot_temp-1-daily-min-ym%4yr%2mo", "all", "min", "none", 2
+"access-om2.mom5.2d.surface_pot_temp.1day.min.%4yr%2mo", 1, "days", 1, "days", "time", 3, "months"
+"ocean_model", "surface_pot_temp", "surface_pot_temp", "access-om2.mom5.2d.surface_pot_temp.1day.min.%4yr%2mo", "all", "min", "none", 2
 
 
 # daily scalar snapshots
 
-"ocean-scalar-1-daily-ym%4yr%2mo", 1, "days", 1, "days", "time", 3, "months"
-"ocean_model", "eta_global", "eta_global", "ocean-scalar-1-daily-ym%4yr%2mo", "all", "none", "none", 1
-"ocean_model", "ke_tot", "ke_tot", "ocean-scalar-1-daily-ym%4yr%2mo", "all", "none", "none", 1
-"ocean_model", "pe_tot", "pe_tot", "ocean-scalar-1-daily-ym%4yr%2mo", "all", "none", "none", 1
-"ocean_model", "rhoave", "rhoave", "ocean-scalar-1-daily-ym%4yr%2mo", "all", "none", "none", 1
-"ocean_model", "salt_global_ave", "salt_global_ave", "ocean-scalar-1-daily-ym%4yr%2mo", "all", "none", "none", 1
-"ocean_model", "salt_surface_ave", "salt_surface_ave", "ocean-scalar-1-daily-ym%4yr%2mo", "all", "none", "none", 1
-"ocean_model", "temp_global_ave", "temp_global_ave", "ocean-scalar-1-daily-ym%4yr%2mo", "all", "none", "none", 1
-"ocean_model", "temp_surface_ave", "temp_surface_ave", "ocean-scalar-1-daily-ym%4yr%2mo", "all", "none", "none", 1
-"ocean_model", "total_net_sfc_heating", "total_net_sfc_heating", "ocean-scalar-1-daily-ym%4yr%2mo", "all", "none", "none", 1
-"ocean_model", "total_ocean_evap_heat", "total_ocean_evap_heat", "ocean-scalar-1-daily-ym%4yr%2mo", "all", "none", "none", 1
-"ocean_model", "total_ocean_evap", "total_ocean_evap", "ocean-scalar-1-daily-ym%4yr%2mo", "all", "none", "none", 1
-"ocean_model", "total_ocean_fprec_melt_heat", "total_ocean_fprec_melt_heat", "ocean-scalar-1-daily-ym%4yr%2mo", "all", "none", "none", 1
-"ocean_model", "total_ocean_fprec", "total_ocean_fprec", "ocean-scalar-1-daily-ym%4yr%2mo", "all", "none", "none", 1
-"ocean_model", "total_ocean_heat", "total_ocean_heat", "ocean-scalar-1-daily-ym%4yr%2mo", "all", "none", "none", 1
-"ocean_model", "total_ocean_hflux_coupler", "total_ocean_hflux_coupler", "ocean-scalar-1-daily-ym%4yr%2mo", "all", "none", "none", 1
-"ocean_model", "total_ocean_hflux_evap", "total_ocean_hflux_evap", "ocean-scalar-1-daily-ym%4yr%2mo", "all", "none", "none", 1
-"ocean_model", "total_ocean_hflux_prec", "total_ocean_hflux_prec", "ocean-scalar-1-daily-ym%4yr%2mo", "all", "none", "none", 1
-"ocean_model", "total_ocean_lprec", "total_ocean_lprec", "ocean-scalar-1-daily-ym%4yr%2mo", "all", "none", "none", 1
-"ocean_model", "total_ocean_lw_heat", "total_ocean_lw_heat", "ocean-scalar-1-daily-ym%4yr%2mo", "all", "none", "none", 1
-"ocean_model", "total_ocean_melt", "total_ocean_melt", "ocean-scalar-1-daily-ym%4yr%2mo", "all", "none", "none", 1
-"ocean_model", "total_ocean_mh_flux", "total_ocean_mh_flux", "ocean-scalar-1-daily-ym%4yr%2mo", "all", "none", "none", 1
-"ocean_model", "total_ocean_pme_river", "total_ocean_pme_river", "ocean-scalar-1-daily-ym%4yr%2mo", "all", "none", "none", 1
-"ocean_model", "total_ocean_river_heat", "total_ocean_river_heat", "ocean-scalar-1-daily-ym%4yr%2mo", "all", "none", "none", 1
-"ocean_model", "total_ocean_river", "total_ocean_river", "ocean-scalar-1-daily-ym%4yr%2mo", "all", "none", "none", 1
-"ocean_model", "total_ocean_runoff_heat", "total_ocean_runoff_heat", "ocean-scalar-1-daily-ym%4yr%2mo", "all", "none", "none", 1
-"ocean_model", "total_ocean_runoff", "total_ocean_runoff", "ocean-scalar-1-daily-ym%4yr%2mo", "all", "none", "none", 1
-"ocean_model", "total_ocean_salt", "total_ocean_salt", "ocean-scalar-1-daily-ym%4yr%2mo", "all", "none", "none", 1
-"ocean_model", "total_ocean_sens_heat", "total_ocean_sens_heat", "ocean-scalar-1-daily-ym%4yr%2mo", "all", "none", "none", 1
-"ocean_model", "total_ocean_sfc_salt_flux_coupler", "total_ocean_sfc_salt_flux_coupler", "ocean-scalar-1-daily-ym%4yr%2mo", "all", "none", "none", 1
-"ocean_model", "total_ocean_swflx_vis", "total_ocean_swflx_vis", "ocean-scalar-1-daily-ym%4yr%2mo", "all", "none", "none", 1
-"ocean_model", "total_ocean_swflx", "total_ocean_swflx", "ocean-scalar-1-daily-ym%4yr%2mo", "all", "none", "none", 1
+"access-om2.mom5.scalar.1day.snap.%4yr%2mo", 1, "days", 1, "days", "time", 3, "months"
+"ocean_model", "eta_global", "eta_global", "access-om2.mom5.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
+"ocean_model", "ke_tot", "ke_tot", "access-om2.mom5.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
+"ocean_model", "pe_tot", "pe_tot", "access-om2.mom5.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
+"ocean_model", "rhoave", "rhoave", "access-om2.mom5.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
+"ocean_model", "salt_global_ave", "salt_global_ave", "access-om2.mom5.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
+"ocean_model", "salt_surface_ave", "salt_surface_ave", "access-om2.mom5.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
+"ocean_model", "temp_global_ave", "temp_global_ave", "access-om2.mom5.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
+"ocean_model", "temp_surface_ave", "temp_surface_ave", "access-om2.mom5.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
+"ocean_model", "total_net_sfc_heating", "total_net_sfc_heating", "access-om2.mom5.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
+"ocean_model", "total_ocean_evap_heat", "total_ocean_evap_heat", "access-om2.mom5.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
+"ocean_model", "total_ocean_evap", "total_ocean_evap", "access-om2.mom5.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
+"ocean_model", "total_ocean_fprec_melt_heat", "total_ocean_fprec_melt_heat", "access-om2.mom5.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
+"ocean_model", "total_ocean_fprec", "total_ocean_fprec", "access-om2.mom5.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
+"ocean_model", "total_ocean_heat", "total_ocean_heat", "access-om2.mom5.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
+"ocean_model", "total_ocean_hflux_coupler", "total_ocean_hflux_coupler", "access-om2.mom5.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
+"ocean_model", "total_ocean_hflux_evap", "total_ocean_hflux_evap", "access-om2.mom5.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
+"ocean_model", "total_ocean_hflux_prec", "total_ocean_hflux_prec", "access-om2.mom5.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
+"ocean_model", "total_ocean_lprec", "total_ocean_lprec", "access-om2.mom5.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
+"ocean_model", "total_ocean_lw_heat", "total_ocean_lw_heat", "access-om2.mom5.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
+"ocean_model", "total_ocean_melt", "total_ocean_melt", "access-om2.mom5.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
+"ocean_model", "total_ocean_mh_flux", "total_ocean_mh_flux", "access-om2.mom5.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
+"ocean_model", "total_ocean_pme_river", "total_ocean_pme_river", "access-om2.mom5.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
+"ocean_model", "total_ocean_river_heat", "total_ocean_river_heat", "access-om2.mom5.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
+"ocean_model", "total_ocean_river", "total_ocean_river", "access-om2.mom5.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
+"ocean_model", "total_ocean_runoff_heat", "total_ocean_runoff_heat", "access-om2.mom5.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
+"ocean_model", "total_ocean_runoff", "total_ocean_runoff", "access-om2.mom5.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
+"ocean_model", "total_ocean_salt", "total_ocean_salt", "access-om2.mom5.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
+"ocean_model", "total_ocean_sens_heat", "total_ocean_sens_heat", "access-om2.mom5.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
+"ocean_model", "total_ocean_sfc_salt_flux_coupler", "total_ocean_sfc_salt_flux_coupler", "access-om2.mom5.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
+"ocean_model", "total_ocean_swflx_vis", "total_ocean_swflx_vis", "access-om2.mom5.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
+"ocean_model", "total_ocean_swflx", "total_ocean_swflx", "access-om2.mom5.scalar.1day.snap.%4yr%2mo", "all", "none", "none", 1
 
 
 # monthly 2d snapshots

--- a/ocean/diag_table_source.yaml
+++ b/ocean/diag_table_source.yaml
@@ -25,10 +25,10 @@ global_defaults:
         - file_name_dimension
         - field_name  # substituted by field name in diag_table section below
         - output_freq
-        - output_freq_units
+        - '':
+            - output_freq_units
         - reduction_method
         - file_name_date
-        # - file_name_date_section
     output_freq: 1  # integer: output sampling frequency in output_freq_units (0: every timestep; -1: only at end of run)
     output_freq_units: months  # time units for output: years, months, days, hours, minutes, or seconds
     file_format: 1  # integer, must be 1, specifying NetCDF (the only format currently supported)
@@ -63,26 +63,20 @@ global_defaults:
     #     8: packed 1-byte (not tested)
 # extra things for constructing filename:
     file_name_dimension: 3d  # descriptor for filename, e.g. 3d, 2d, scalar
-    file_name_prefix: ocean
-    file_name_date: "ym%4yr%2mo"  # run date/time of file opening; format: %, 1 digit (#digits), one of (yr, mo, dy, hr, mi, sc); date/time components will be separated by _ in filename.
-    file_name_separator: "-"  # used to separate filename components; best not to use "_" to avoid confusion with fields and dates
+    file_name_prefix: access-om2.mom5
+    file_name_date: "%4yr%2mo"  # run date/time of file opening; format: %, 1 digit (#digits), one of (yr, mo, dy, hr, mi, sc); date/time components will be separated by _ in filename.
+    file_name_separator: "."  # used to separate filename components; best not to use "_" to avoid confusion with fields and dates
     file_name_omit_empty: true  # whether to omit empty filename components to avoid duplicate file_name_separator
     file_name_substitutions:  # string replacements for filename components
-        years: yearly
-        months: monthly
-        days: daily
-        hours: hourly
+        years: yr
+        months: mon
+        days: day
+        hours: hr
         none: snap  # careful! will apply to both reduction_method and regional_section
         'False': snap
         average: mean
         'True': mean
         None: ""  # for empty items
-    file_name_date_section:  # These are separated by "_". If file_name_date is used, it must be the last item.
-        - output_freq
-        - output_freq_units
-        - reduction_method
-        - file_name_date
-
 
 #######################################################################################################
 # diag_table section - this defines the diagnostics that will appear in diag_table.
@@ -114,6 +108,8 @@ diag_table:
                 - file_name_prefix
                 - file_name_dimension
                 - field_name  # substituted by field name in fields section below
+                - file_name_frequency # this is a hack to get 'fx' in the filename
+            file_name_frequency: fx
             reduction_method: snap  # mean, snap, rms, pow##, min, max, or diurnal##
             output_freq: -1  # Output frequency in output_freq_units (0: every timestep; -1: only at end of run)
             new_file_freq:  # optional integer: frequency (in new_file_freq_units) for closing the existing file, and creating a new file
@@ -298,7 +294,9 @@ diag_table:
                 - file_name_prefix
                 - file_name_dimension
                 - output_freq
-                - output_freq_units
+                - '':
+                    - output_freq_units
+                - reduction_method
                 - file_name_date
             output_freq: 1  # integer: output sampling frequency in output_freq_units (0: every timestep; -1: only at end of run)
             output_freq_units: days  # time units for output: years, months, days, hours, minutes, or seconds


### PR DESCRIPTION
This PR updates the MOM diagnostic filenames to use our standardised format.

I'll cherry-pick into the `iaf` branch once approved.

Contributes to https://github.com/ACCESS-NRI/access-om2-configs/issues/328