### PR TITLE
Update to access-om2/2026.05.000: `dev-025deg_jra55_ryf`

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -22,7 +22,7 @@ modules:
   use:
       - /g/data/vk83/modules
   load:
-      - access-om2/2026.02.001
+      - access-om2/2026.05.000
       - model-tools/mppnccombine-fast/2025.07.000
 
 # Model configuration

--- a/manifests/exe.yaml
+++ b/manifests/exe.yaml
@@ -2,17 +2,17 @@ format: yamanifest
 version: 1.0
 ---
 work/atmosphere/yatm.exe:
-  fullpath: /g/data/vk83/apps/spack/1.1/release/linux-x86_64_v4/libaccessom2-git.2026.02.000_access-om2-r3azt3fmu7nvbyl5qwqxy6ptyooekm57/bin/yatm.exe
+  fullpath: /g/data/vk83/apps/spack/1.1/release/linux-x86_64_v4/libaccessom2-git.2026.02.000_access-om2-ufu526k572oolu2fgvqfkmhjmoyv3nul/bin/yatm.exe
   hashes:
-    binhash: 28322108e7828d81d3eca60d3a0a3fa6
-    md5: 55cab0f7f507c6425818fee5f109168a
+    binhash: 173d9ad62ba9fee420b0847361c227aa
+    md5: 2010d006893c0a0d369871b382a00caa
 work/ice/cice_auscom_1440x1080_30x27.exe:
-  fullpath: /g/data/vk83/apps/spack/1.1/release/linux-x86_64_v4/cice5-2026.01.000-d6y75tbsvjsa6gc3uh4aq4gtqmssvvgm/bin/cice_auscom_1440x1080_30x27.exe
+  fullpath: /g/data/vk83/apps/spack/1.1/release/linux-x86_64_v4/cice5-2026.01.000-ejgeocvmftheyzq4bfxktpjghv44adfp/bin/cice_auscom_1440x1080_30x27.exe
   hashes:
-    binhash: 2ba2bf9c792964431022d7c4d155a17b
-    md5: ef9f52b0aec64bba412b766636bb4879
+    binhash: 0fc624b1a4f37eedf072a60b60972fff
+    md5: 5efc82ce31216490d8e9fc809b85c557
 work/ocean/mom5_access_om:
-  fullpath: /g/data/vk83/apps/spack/1.1/release/linux-x86_64_v4/mom5-git.2026.02.000_access-om2-4urwevrv4wqd3ol6ogaplg6rd4r6biag/bin/mom5_access_om
+  fullpath: /g/data/vk83/apps/spack/1.1/release/linux-x86_64_v4/mom5-git.2026.02.000_access-om2-vxwlyl73pevmx7n7xvjpoaq4h2c4z7yy/bin/mom5_access_om
   hashes:
-    binhash: 93696b2298f35daff4db7dc3b66fec89
-    md5: 80748c44ebae5ade99e30698f53f7fc3
+    binhash: eb9a1bfad744b38ecd3484c998cee9f3
+    md5: 15b1ca2e30aadedaa769cba79226a74b


### PR DESCRIPTION
This update doesn't change answers for non-wombat configs. It's just so that there is consistency in the version used across configs.

Contributes to #335 