### PR TITLE
Update payu-version to 1.3.2 in ci.json

### DIFF
--- a/config/ci.json
+++ b/config/ci.json
@@ -7,7 +7,7 @@
         },
         "release-.*": {
             "model-config-tests-version": "0.2.3",
-            "payu-version": "1.2.1"
+            "payu-version": "1.3.2"
         }
     },
     "reproducibility": {
@@ -16,7 +16,7 @@
         },
         "release-.*": {
             "model-config-tests-version": "0.2.3",
-            "payu-version": "1.2.1"
+            "payu-version": "1.3.2"
         }
     },
     "qa": {
@@ -25,7 +25,7 @@
         },
         "release-.*": {
             "model-config-tests-version": "0.2.3",
-            "payu-version": "1.2.1"
+            "payu-version": "1.3.2"
         }
     },
     "default": {


### PR DESCRIPTION
We need to update these because our configs now have:

```
payu_minimum_version: 1.3.0
```