### PR TITLE
Update scheduled CI tests

### DIFF
--- a/config/ci.json
+++ b/config/ci.json
@@ -1,10 +1,11 @@
 {
     "$schema": "https://github.com/ACCESS-NRI/schema/tree/main/au.org.access-nri/model/configuration/ci/2-0-0.json",
     "scheduled": {
-        "release-1deg_jra55_ryf-2.0": {},
         "default": {
-            "markers": "repro and (not slow)"
+            "markers": "repro or access_om2 or config"
         },
+        "release-1deg_jra55_ryf+wombatlite": {},
+        "release-025deg_jra55_iaf": {},
         "release-.*": {
             "model-config-tests-version": "0.2.4",
             "payu-version": "1.3.2"


### PR DESCRIPTION
This PR updates the scheduled CI tests to:
- run the markers `repro or access_om2 or config` (previously `repro and (not slow)` so not including repro restart or determinism)
- run the latest `release-1deg_jra55_ryf+wombatlite` and `release-025deg_jra55_iaf` branches (previous an old release of `release-1deg_jra55_ryf-2.0`)

The justification for the branches tested is:
- covers ryf and iaf (at 025 deg where we've previously had unnoticed repro issues)
- covers wombatlite (at lowest res to reduce cost/time)
- small number of configs to reduce the number of erroneous failures (e.g. due to ssh issues)

Closes #350 